### PR TITLE
Test missings

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,7 @@ makedocs(
         "Storage Backends" => "storage.md",
         "Accessing cloud data Examples" => "s3examples.md",
         "Operations on Zarr Arrays" => "operations.md",
+        "Dealing with missing values" => "missings.md",
     ]
 )
 

--- a/docs/src/missings.md
+++ b/docs/src/missings.md
@@ -1,0 +1,83 @@
+# Dealing with FillValues
+
+In Zarr metadata, a fillvalue is specified for every array. This means that, when creating an empty array, uninitialized chunks will be assumed to be filled with this value. For example:
+
+````jldoctest fillval
+julia> using Zarr
+
+julia> p = tempname();
+
+julia> z = zcreate(Int64, 100, 100, path = p, chunks = (10,10), fill_value=-1, fill_as_missing=false)
+ZArray{Int64} of size 100 x 100
+
+julia> z[1:2,1]
+2-element Vector{Int64}:
+ -1
+ -1
+
+````
+
+Note that except some array metadata, no chunks will be written to disk in this case. Non-existing chunks are simply interpreted as fillvalues. You can check this with:
+
+````jldoctest fillval
+julia> readdir(p)
+2-element Vector{String}:
+ ".zarray"
+ ".zattrs"
+````
+
+and only after writing some non-fillvalue data there will be chunks on disk:
+
+````jldoctest fillval
+julia> z[1:20,1:10] .= 5
+Disk Array with size 20 x 10
+
+
+julia> readdir(p)
+4-element Vector{String}:
+ ".zarray"
+ ".zattrs"
+ "0.0"
+ "0.1"
+````
+
+Also be aware that during `setindex!`, when chunks only contain FillValues, the chunk will not be written to disk or deleted if it existed before. So if we write `-1`s again into our array, the corresponding chunks will be deleted.
+
+````jldoctest fillval
+julia> z[1:10,1:10] .= -1
+Disk Array with size 10 x 10
+
+
+julia> readdir(p)
+3-element Vector{String}:
+ ".zarray"
+ ".zattrs"
+ "0.1"
+````
+
+
+## Dealing with Julia's Missing type in Zarr.jl
+
+Like most data storage formats, also Zarr supports storing most of the standard C-compatible data types like integers, unsigned integers and floating point types of different sizes. This Means that it is no problem to directly map a `Vector{Int64}` to a Zarr array. However, the story gets complicated for arrays containing missings with a Union element type like `Union{Int64,Missing}`, since they can not be passed to compression lbraries as simple C pointers and are not very inter-operable with other lanugages. 
+
+One solution to this problem is to use Zarrs `fillvalue`s to represent missing values. Here we open the previously created array and use the `fill_as_missing` option. In this case accessing an uninitialized array member will return missing:
+
+```jldoctest fillval
+julia> z = zopen(p, fill_as_missing=true)
+ZArray{Union{Missing, Int64}} of size 100 x 100
+
+julia> eltype(z)
+Union{Missing, Int64}
+
+julia> z[8:12,1]
+5-element reshape(::Matrix{Union{Missing, Int64}}, 5) with eltype Union{Missing, Int64}:
+  missing
+  missing
+  missing
+ 5
+ 5
+
+```
+
+
+

--- a/docs/src/missings.md
+++ b/docs/src/missings.md
@@ -79,5 +79,7 @@ julia> z[8:12,1]
 
 ```
 
+The `fill_as_missing` option is also available on array construction with `zcreate`, `zopen` or `zzeros`. 
+Note also that one can also write missings into arrays opened with `fill_as_missing=true`. This means that every `missing` entry will be converted to a fillvalue in the zarr array and will appear as fill values in other software that opens the same array. 
 
 

--- a/docs/src/s3examples.md
+++ b/docs/src/s3examples.md
@@ -143,7 +143,7 @@ Next we create a new zarr group in the just created bucket:
 
 ````@example minio
 using Zarr
-g = zgroup(S3Store("zarrdata","group_1"))
+g = zgroup(S3Store("zarrdata"),"group_1")
 ````
 
 and a new array inside the group and fill it with some data:

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -51,7 +51,7 @@ julia> z[end,end]
 42
 
 julia> z[1,:]
-10000-element Array{Int32,1}:
+10000-element Vector{Int32}:
      1
      2
      3
@@ -75,7 +75,7 @@ julia> z[1,:]
 
 
 julia> z[1:5,1:10]
-5×10 Array{Int32,2}:
+5×10 Matrix{Int32}:
  1   2   3   4   5   6   7   8   9  10
  2  42  42  42  42  42  42  42  42  42
  3  42  42  42  42  42  42  42  42  42
@@ -199,8 +199,8 @@ Compressor          : Zarr.BloscCompressor(0, 3, "zstd", true)
 Filters             : nothing
 Store type          : Dictionary Storage
 No. bytes           : 400000000
-No. bytes stored    : 2412230
-Storage ratio       : 165.82166708813008
+No. bytes stored    : 2412289
+Storage ratio       : 165.81761140559857
 Chunks initialized  : 100/100
 ```
 
@@ -222,7 +222,7 @@ If you need to store an array of arrays, where each member array can be of any l
 
 ```jldoctest ragged
 julia> z = zcreate(Vector{Int}, 4)
-ZArray{Array{Int64,1}} of size 4
+ZArray{Vector{Int64}} of size 4
 
 julia> z.metadata.filters
 (Zarr.VLenArrayFilter{Int64}(),)
@@ -230,7 +230,7 @@ julia> z.metadata.filters
 julia> z[1:3] = [[1,3,5],[4],[7,9,14]];
 
 julia> z[:]
-4-element Array{Array{Int64,1},1}:
+4-element Vector{Vector{Int64}}:
  [1, 3, 5]
  [4]
  [7, 9, 14]

--- a/src/Storage/http.jl
+++ b/src/Storage/http.jl
@@ -29,10 +29,9 @@ push!(storageregexlist,r"^https://"=>HTTPStore)
 push!(storageregexlist,r"^http://"=>HTTPStore)
 storefromstring(::Type{<:HTTPStore}, s,_) = ConsolidatedStore(HTTPStore(s),""),""
 
+
+
 ## This is a server implementation for Zarr datasets
-
-
-
 function zarr_req_handler(s::AbstractStore, p)
   if s[p,".zmetadata"] === nothing
     consolidate_metadata(s)

--- a/src/ZGroup.jl
+++ b/src/ZGroup.jl
@@ -43,9 +43,9 @@ function zopen_noerr(s::AbstractStore, mode="r";
   consolidated = false, 
   path="", 
   lru = 0,
-  fill_as_missing = deprec_fillvalue())
+  fill_as_missing)
     consolidated && isinitialized(s,".zmetadata") && return zopen(ConsolidatedStore(s, path), mode, path=path,lru=lru,fill_as_missing=fill_as_missing)
-    lru !== 0 && return zopen(LRUStore(s,maxsize=lru),mode,path=path,lru=lru,fill_as_missing=fill_as_missing)
+    lru !== 0 && !isa(s,LRUStore) && return zopen(LRUStore(s,maxsize=lru),mode,path=path,lru=lru,fill_as_missing=fill_as_missing)
     if is_zarray(s, path)
         return ZArray(s,mode,path;fill_as_missing=fill_as_missing)
     elseif is_zgroup(s,path)

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -152,7 +152,7 @@ function Metadata(A::AbstractArray{T, N}, chunks::NTuple{N, Int};
         fill_value::Union{T, Nothing}=nothing,
         order::Char='C',
         filters::Nothing=nothing,
-        fill_as_missing = deprec_fillvalue(),
+        fill_as_missing = fill_value !== nothing && deprec_fillvalue(),
     ) where {T, N, C}
     T2 = (fill_value === nothing || !fill_as_missing) ? T : Union{T,Missing}
     Metadata{T2, N, C, typeof(filters)}(

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -101,15 +101,19 @@ end
   chunks = (5,10)
   metadata = Zarr.Metadata(A, chunks; fill_value=-1.5)
   using Minio
-  s = Minio.Server(joinpath("./",tempname()), address="localhost:9001")
-  run(s, wait=false)
-  cfg = MinioConfig("http://localhost:9001")
-  Zarr.AWS.global_aws_config(cfg)
-  Zarr.S3.create_bucket("zarrdata")
-  ds = S3Store("zarrdata")
-  test_store_common(ds)
-  @test sprint(show, ds) == "S3 Object Storage"
-  kill(s)
+  if !isempty(Minio.getexe())
+    s = Minio.Server(joinpath("./",tempname()), address="localhost:9001")
+    run(s, wait=false)
+    cfg = MinioConfig("http://localhost:9001")
+    Zarr.AWS.global_aws_config(cfg)
+    Zarr.S3.create_bucket("zarrdata")
+    ds = S3Store("zarrdata")
+    test_store_common(ds)
+    @test sprint(show, ds) == "S3 Object Storage"
+    kill(s)
+  else
+    @warn "Skipping Minio Tests, because the package was not built correctly"
+  end
 end
 
 @testset "AWS S3 Storage" begin


### PR DESCRIPTION
This is a start to fix #79 which adds a warning every time an array is opened that contains fillvalues. Currently these are interpreted as `missing`, and after this PR there will be a warning that this behavior will change in the future. Users are encouraged to explicitly use `fill_as_missing` keyword to avoid breakages in the next release. 

I also added a section in the docs about the treatment of fillvalues and missings. 