### PR TITLE
Metadata sanity

### DIFF
--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -336,6 +336,7 @@ Resizes a `ZArray` to the new specified size. If the size along any of the
 axes is decreased, unused chunks will be deleted from the store.
 """
 function Base.resize!(z::ZArray{T,N}, newsize::NTuple{N}) where {T,N}
+    any(<(0), newsize) && throw(ArgumentError("Size must be positive"))
     oldsize = z.metadata.shape[]
     z.metadata.shape[] = newsize
     #Check if array was shrunk

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -129,6 +129,15 @@ struct Metadata{T, N, C, F}
     fill_value::Union{T, Nothing}
     order::Char
     filters::F  # not yet supported
+    function Metadata{T2, N, C, F}(zarr_format, shape, chunks, dtype, compressor,fill_value, order, filters) where {T2,N,C,F}
+        #We currently only support version 
+        zarr_format == 2 || throw(ArgumentError("Zarr.jl currently only support v2 of the protocol"))
+        #Do some sanity checks to make sure we have a sane array
+        any(<(0), shape) && throw(ArgumentError("Size must be positive"))
+        any(<(1), chunks) && throw(ArgumentError("Chunk size must be >= 1 along each dimension"))
+        order === 'C' || throw(ArgumentError("Currently only 'C' storage order is supported"))
+        new{T2, N, C, F}(zarr_format, shape, chunks, dtype, compressor,fill_value, order, filters)
+    end
 end
 
 #To make unit tests pass with ref shape

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -212,6 +212,7 @@ end
   append!(a,vcat(singlerow', singlerow'), dims=1)
   @test size(a)==(13,31)
   @test a[12:13,:]==vcat(singlerow', singlerow')
+  @test_throws ArgumentError resize!(a,(-1,2))
 end
 
 @testset "string array getindex/setindex" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,10 @@ end
         @test z.metadata.compressor.shuffle === true
         @test z.attrs == Dict{Any, Any}()
         @test z.writeable === true
+        @test_throws ArgumentError zzeros(Int64,2,3, chunks = (0,1))
+        @test_throws ArgumentError zzeros(Int64,0,-1)
+        @test_throws ArgumentError Zarr.Metadata(zeros(2,2), (2,2), zarr_format = 3)
+        @test_throws ArgumentError Zarr.Metadata(zeros(2,2), (2,2), order = 'F')
     end
 
     @testset "methods" begin


### PR DESCRIPTION
This makes sure that we can not create ZArrays with zero chunk size, negative sizes etc...