### PR TITLE
Vlen utf8

### DIFF
--- a/src/Filters.jl
+++ b/src/Filters.jl
@@ -51,8 +51,46 @@ function zencode(ain,::VLenArrayFilter)
     take!(b)
 end
 
-JSON.lower(::VLenArrayFilter{T}) where T = Dict("id"=>"vlen-array","dtype"=> typestr(T) )
+JSON.lower(::VLenArrayFilter{T}) where T = Dict("id"=>"vlen-array","dtype"=> typestr(eltype(T)) )
 
-getfilter(::Type{<:VLenArrayFilter}, f) = VLenArrayFilter{typestr(f["dtype"])}()
+getfilter(::Type{<:VLenArrayFilter}, f) = VLenArrayFilter{Vector{typestr(f["dtype"])}}()
 
-filterdict = Dict("vlen-array"=>VLenArrayFilter)
+"""
+    VLenUTF8Filter
+
+Encodes and decodes variable-length arrays of arbitrary data type 
+"""
+struct VLenUTF8Filter <: Filter{String,UInt8} end
+
+function zdecode(ain, ::VLenUTF8Filter)
+    arbuf = UInt8[]
+    f = IOBuffer(ain)
+    nitems = read(f, UInt32)
+    out = Array{String}(undef,nitems)
+    for i=1:nitems
+        len1 = read(f,UInt32)
+        resize!(arbuf,len1)
+        read!(f,arbuf)
+        out[i] = String(arbuf)
+    end
+    close(f)
+    out
+end
+
+#Encodes Array of Vectors a into bytes
+function zencode(ain,::VLenUTF8Filter)
+    b = IOBuffer()
+    nitems = length(ain)
+    write(b,UInt32(nitems))
+    for a in ain
+        write(b, UInt32(sizeof(a)))
+        write(b, a)
+    end
+    take!(b)
+end
+
+JSON.lower(::VLenUTF8Filter) = Dict("id"=>"vlen-utf8","dtype"=> "|O" )
+
+getfilter(::Type{<:VLenUTF8Filter}, f) = VLenUTF8Filter()
+
+filterdict = Dict("vlen-array"=>VLenArrayFilter, "vlen-utf8"=>VLenUTF8Filter)

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -96,7 +96,7 @@ function typestr(s::AbstractString, filterlist=nothing)
             if filterlist === nothing
                 throw(ArgumentError("Object array can only be parsed when an appropriate filter is defined"))
             end
-            return Vector{sourcetype(first(filterlist))}
+            return sourcetype(first(filterlist))
         end
         isempty(typesize) && throw((ArgumentError("$s is not a valid numpy typestr")))
         tc, ts = first(typecode), parse(Int, typesize)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,6 +232,7 @@ end
   a, b, c, d = [1.0,2.0,3.0], [4.0,5.0],[2.0],[2.0,3.0]
   z[1,1] = a
   z[2,1:3] = [b,c,d]
+  z[1,2:3] = [[],[]]
   @test z[:,:] == reshape([a,b,[],c,[],d],2,3)
   @test storageratio(z) == "unknown"
   @test zinfo(z) === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,7 +228,7 @@ end
 end
 
 @testset "ragged arrays" begin
-  z = zcreate(Vector{Float64},2,3)
+  z = zcreate(Vector{Float64},2,3,chunks=(1,1))
   a, b, c, d = [1.0,2.0,3.0], [4.0,5.0],[2.0],[2.0,3.0]
   z[1,1] = a
   z[2,1:3] = [b,c,d]


### PR DESCRIPTION
This adds support for the vlen-utf8 filter, which supports reading and writing of non-fixed length string. Unit tests and docs are still on the way.