### PR TITLE
Fix signatures

### DIFF
--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -227,7 +227,7 @@ Creates a new empty zarr aray with element type `T` and array dimensions `dims`.
 * `attrs=Dict()` a dict containing key-value pairs with metadata attributes associated to the array
 * `writeable=true` determines if the array is opened in read-only or write mode
 """
-function zcreate(::Type{T}, dims...;
+function zcreate(::Type{T}, dims::Integer...;
         name="",
         path=nothing,
         kwargs...

--- a/src/ZGroup.jl
+++ b/src/ZGroup.jl
@@ -145,9 +145,9 @@ function zgroup(g::ZGroup, name; attrs=Dict())
 end
 
 "Create a new subarray of the group g"
-function zcreate(::Type{T},g::ZGroup, name::String, addargs...; kwargs...) where T
+function zcreate(::Type{T},g::ZGroup, name::AbstractString, addargs...; kwargs...) where T
   g.writeable || throw(IOError("Zarr group is not writeable. Please re-open in write mode to create an array"))
-
+  name = string(name)
   z = zcreate(T, g.storage, addargs...; path = _concatpath(g.path,name), kwargs...)
   g.arrays[name] = z
   return z


### PR DESCRIPTION
This fixes a few corner cases when the name of an array to be added to a group is not a plain `String`