### PR TITLE
Fill_as_missing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Zarr"
 uuid = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.7.3"
+version = "0.8.0"
 
 [deps]
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"

--- a/docs/src/missings.md
+++ b/docs/src/missings.md
@@ -7,7 +7,7 @@ julia> using Zarr
 
 julia> p = tempname();
 
-julia> z = zcreate(Int64, 100, 100, path = p, chunks = (10,10), fill_value=-1, fill_as_missing=false)
+julia> z = zcreate(Int64, 100, 100, path = p, chunks = (10,10), fill_value=-1)
 ZArray{Int64} of size 100 x 100
 
 julia> z[1:2,1]

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -221,7 +221,7 @@ Creates a new empty zarr aray with element type `T` and array dimensions `dims`.
 * `storagetype` determines the storage to use, current options are `DirectoryStore` or `DictStore`
 * `chunks=dims` size of the individual array chunks, must be a tuple of length `length(dims)`
 * `fill_value=nothing` value to represent missing values
-* `fill_as_missing=true` set to `true` shall fillvalue s be converted to `missing`s
+* `fill_as_missing=false` set to `true` shall fillvalue s be converted to `missing`s
 * `filters`=filters to be applied
 * `compressor=BloscCompressor()` compressor type and properties
 * `attrs=Dict()` a dict containing key-value pairs with metadata attributes associated to the array
@@ -245,7 +245,7 @@ function zcreate(::Type{T},storage::AbstractStore,
         path = "",
         chunks=dims,
         fill_value=nothing,
-        fill_as_missing=fill_value !== nothing && deprec_fillvalue(),
+        fill_as_missing=false,
         compressor=BloscCompressor(),
         filters = filterfromtype(T), 
         attrs=Dict(),

--- a/src/ZGroup.jl
+++ b/src/ZGroup.jl
@@ -88,7 +88,7 @@ function zopen(s::AbstractStore, mode="r";
   consolidated = false, 
   path = "", 
   lru = 0,
-  fill_as_missing = deprec_fillvalue())
+  fill_as_missing = false)
     # add interfaces to Stores later    
     r = zopen_noerr(s,mode; consolidated=consolidated, path=path, lru=lru, fill_as_missing=fill_as_missing)
     if r === nothing

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -161,7 +161,7 @@ function Metadata(A::AbstractArray{T, N}, chunks::NTuple{N, Int};
         fill_value::Union{T, Nothing}=nothing,
         order::Char='C',
         filters::Nothing=nothing,
-        fill_as_missing = fill_value !== nothing && deprec_fillvalue(),
+        fill_as_missing = false,
     ) where {T, N, C}
     T2 = (fill_value === nothing || !fill_as_missing) ? T : Union{T,Missing}
     Metadata{T2, N, C, typeof(filters)}(
@@ -177,14 +177,6 @@ function Metadata(A::AbstractArray{T, N}, chunks::NTuple{N, Int};
 end
 
 Metadata(s::Union{AbstractString, IO},fill_as_missing) = Metadata(JSON.parse(s),fill_as_missing)
-
-function deprec_fillvalue()
-    @warn """In the future, fill values will not be interpreted as missing values by default. 
-    Please set the keyword argument `fill_as_missing` to a boolean accordingly. Setting to `true`
-    for now, but in the future `false` will be the default.
-    """
-    true
-end
 
 "Construct Metadata from Dict"
 function Metadata(d::AbstractDict, fill_as_missing)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,7 +198,7 @@ end
   @test size(a)==(5,4)
   resize!(a,10,10)
   @test size(a)==(10,10)
-  @test all(ismissing,a[6:end,:])
+  @test all(==(-1),a[6:end,:])
   xapp = rand(1:10,10,20)
   append!(a,xapp)
   @test size(a)==(10,30)
@@ -241,6 +241,22 @@ end
   z2 = ZArray(reshape([a,b,Float64[],c,Float64[],d],2,3))
   @test z[:,:] == z2[:,:]
 end
+
+@testset "Fillvalue as missing" begin 
+    p = tempname()
+    a = zcreate(Int,2,3,fill_value=-1,fill_as_missing=true,path=p)
+    @test all(ismissing,a[:,:])
+    @test eltype(a) == Union{Int,Missing}
+    a[:,1] .= 5
+    b = zopen(p,fill_as_missing=true)
+    @test eltype(b) == Union{Int, Missing}
+    @test all(ismissing,b[:,2:3])
+    @test all(==(5),b[:,1])
+    c = zopen(p)
+    @test eltype(c) == Int
+    @test all(==(-1),c[:,2:3])
+    @test all(==(5),c[:,1])
+  end
 
 include("storage.jl")
 

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -97,7 +97,7 @@ end
   @test all(iszero,a2[1:10,1])
   @test_throws ErrorException a2[1,1] = 5
   @test_throws ErrorException delete!(newstore,"foo/0.0")
-  @test isequal(a2[1,1000], missing)
+  @test isnan(a2[1,1000])
   @test storagesize(a2) == 83002
 end
 
@@ -146,10 +146,10 @@ end
     g = zopen(cmip6,path=p)
     arr = g["psl"]
     @test size(arr) == (288, 192, 97820)
-    @test eltype(arr) == Union{Missing, Float32}
+    @test eltype(arr) == Float32
     lat = g["lat"]
     @test size(lat) == (192,)
-    @test eltype(lat) == Union{Missing, Float64}
+    @test eltype(lat) == Float64
     @test lat[1:4] == [-90.0,-89.05759162303664,-88.1151832460733,-87.17277486910994]
   end
 end


### PR DESCRIPTION
Do not interpret fill values as missing anymore. This will be a breaking change and will silence the warning introduced in 0.7