### PR TITLE
Support bitshuffle in `BloscCompressor`

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -171,7 +171,7 @@ A number of different compressors can be used with Zarr. In this Julia package w
 julia> using Zarr
 
 julia> compressor = Zarr.BloscCompressor(cname="zstd", clevel=3, shuffle=true)
-Zarr.BloscCompressor(0, 3, "zstd", true)
+Zarr.BloscCompressor(0, 3, "zstd", 1)
 
 julia> data = Int32(1):Int32(100000000)
 1:100000000
@@ -195,7 +195,7 @@ Shape               : (10000, 10000)
 Chunk Shape         : (1000, 1000)
 Order               : C
 Read-Only           : false
-Compressor          : Zarr.BloscCompressor(0, 3, "zstd", true)
+Compressor          : Zarr.BloscCompressor(0, 3, "zstd", 1)
 Filters             : nothing
 Store type          : Dictionary Storage
 No. bytes           : 400000000

--- a/src/Compressors.jl
+++ b/src/Compressors.jl
@@ -40,34 +40,48 @@ struct BloscCompressor <: Compressor
     blocksize::Int
     clevel::Int
     cname::String
-    shuffle::Bool
+    shuffle::Int
 end
 
 """
-    BloscCompressor(;blocksize=0, clevel=5, cname="lz4", shuffle=true)
+    BloscCompressor(;blocksize=0, clevel=5, cname="lz4", shuffle=1)
 
 Returns a `BloscCompressor` struct that can serve as a Zarr array compressor. Keyword arguments are:
 
 * `clevel=5` the compression level, number between 0 (no compression) and 9 (max compression)
 * `cname="lz4"` compressor name, can be one of `"blosclz"`, `"lz4"`, and `"lz4hc"`
-* `shuffle=true` enables/disables bit-shuffling
+* `shuffle=1` Either NOSHUFFLE (0), SHUFFLE (1), BITSHUFFLE (2) or AUTOSHUFFLE (-1). 
+    If AUTOSHUFFLE, bit-shuffle will be used for buffers with itemsize 1, and byte-shuffle will be used otherwise. The default is SHUFFLE.
 """
-BloscCompressor(;blocksize=0, clevel=5, cname="lz4", shuffle=true) =
+BloscCompressor(;blocksize=0, clevel=5, cname="lz4", shuffle=1) =
     BloscCompressor(blocksize, clevel, cname, shuffle)
 
 function getCompressor(::Type{BloscCompressor}, d::Dict)
-    BloscCompressor(d["blocksize"], d["clevel"], d["cname"], d["shuffle"] > 0)
+    BloscCompressor(d["blocksize"], d["clevel"], d["cname"], d["shuffle"])
 end
 
 zuncompress(a, ::BloscCompressor, T) = Blosc.decompress(Base.nonmissingtype(T), a)
 
 function zcompress(a, c::BloscCompressor)
+    itemsize = sizeof(eltype(a))
+    shuffle = c.shuffle
+    # Weird auto shuffle logic from 
+    # https://github.com/zarr-developers/numcodecs/blob/7d8f9762b4f0f9b5e135688b2eeb3f783f90f208/numcodecs/blosc.pyx#L264-L272
+    if shuffle == -1
+        if itemsize == 1
+            shuffle = Blosc.BITSHUFFLE
+        else
+            shuffle = Blosc.SHUFFLE
+        end
+    elseif shuffle ∉ (Blosc.NOSHUFFLE, Blosc.SHUFFLE, Blosc.BITSHUFFLE)
+        throw(ArgumentError("invalid shuffle argument; expected -1, 0, 1 or 2, found $shuffle"))
+    end
     Blosc.set_compressor(c.cname)
-    Blosc.compress(a, level=c.clevel, shuffle=c.shuffle)
+    Blosc.compress(a; level=c.clevel, shuffle=shuffle)
 end
 
 JSON.lower(c::BloscCompressor) = Dict("id"=>"blosc", "cname"=>c.cname,
-    "clevel"=>c.clevel, "shuffle"=>c.shuffle ? 1 : 0, "blocksize"=>c.blocksize)
+    "clevel"=>c.clevel, "shuffle"=>c.shuffle, "blocksize"=>c.blocksize)
 
 """
     NoCompressor()

--- a/test/python.jl
+++ b/test/python.jl
@@ -28,7 +28,13 @@ dtypes = (UInt8, UInt16, UInt32, UInt64,
     Float16, Float32, Float64,
     Complex{Float32}, Complex{Float64},
     Bool,MaxLengthString{10,UInt8},MaxLengthString{10,UInt32})
-compressors = ("no"=>NoCompressor(), "blosc"=>BloscCompressor(cname="zstd"),"zlib"=>ZlibCompressor())
+compressors = (
+    "no"=>NoCompressor(),
+    "blosc"=>BloscCompressor(cname="zstd"),
+    "blosc_autoshuffle"=>BloscCompressor(cname="zstd",shuffle=-1),
+    "blosc_noshuffle"=>BloscCompressor(cname="zstd",shuffle=0),
+    "blosc_bitshuffle"=>BloscCompressor(cname="zstd",shuffle=2),
+    "zlib"=>ZlibCompressor())
 testarrays = Dict(t=>(t<:AbstractString) ? [randstring(maximum(i.I)) for i in CartesianIndices((1:10,1:6,1:2))] : rand(t,10,6,2) for t in dtypes)
 
 for t in dtypes, co in compressors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ end
         @test z.metadata.compressor.blocksize === 0
         @test z.metadata.compressor.clevel === 5
         @test z.metadata.compressor.cname === "lz4"
-        @test z.metadata.compressor.shuffle === true
+        @test z.metadata.compressor.shuffle === 1
         @test z.attrs == Dict{Any, Any}()
         @test z.writeable === true
         @test_throws ArgumentError zzeros(Int64,2,3, chunks = (0,1))


### PR DESCRIPTION
Implements #102 by changing the `shuffle` field of `BloscCompressor` from `Bool` to `Int`.

I think this is a non breaking change, because calling the contructor with `shuffle=true` will still result in the byte shuffle being used and  `shuffle=false` will still result in no shuffle being used, because `true` and `false` are auto converted to 1 and 0. 