### PR TITLE
feat: abstract dict store

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Zarr"
-uuid = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.8.0"
+uuid = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
+version = "99.0.0"
 
 [deps]
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"


### PR DESCRIPTION
Abstract dict store, for using it as backend for dict implementations, like lmdb:
```julia
import Zarr;
const za = Zarr;
import LMDB;
const lm = LMDB;

struct LMDBDictStore <: za.AbstractDictStore
    a::lm.LMDBDict
    LMDBDictStore(path::AbstractString) = begin
        !ispath(path) && mkpath(path)
        new(lm.LMDBDict{String,Vector{UInt8}}(path))
    end
end

Base.filter!(f, d::lm.LMDBDict) = begin
    collect(v for v in pairs(d) if f(v))
end
```
I made the function only iterate over values for the `storagesize` as otherwise the dict (like lmdb) would have to read the values for all the other key ops too