### PR TITLE
Update API documentation page

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,7 @@ makedocs(
     pages = [
         "Home" => "index.md",
         "Tutorial" => "tutorial.md",
-        "Function Reference" => "reference.md",
+        "API Reference" => "reference.md",
         "Storage Backends" => "storage.md",
         "Accessing cloud data Examples" => "s3examples.md",
         "Operations on Zarr Arrays" => "operations.md",

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,13 +1,22 @@
-## Array creation
+# API reference
+
+## Arrays
 
 ```@docs
 zcreate
 zzeros
 ```
 
+## Group hierarchy
+
+```@autodocs
+Modules = [Zarr]
+Pages = ["ZGroup.jl"]
+```
+
 ## Compressors
 
-```@docs
-Zarr.BloscCompressor
-Zarr.NoCompressor
+```@autodocs
+Modules = [Zarr]
+Pages = ["Compressors.jl"]
 ```


### PR DESCRIPTION
### Changes

* Add section for `ZGroup`
* Use `@autodocs` block for `Compressors` to include all the types
* Rename 'Function Reference' -> 'API Reference' and add H1 header

Fix #113.