### PR TITLE
Change repo in docs/make.jl to fix deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -22,5 +22,5 @@ zarrpath = joinpath(@__DIR__, "data", "example.zarr")
 isdir(zarrpath) && rm(zarrpath, recursive=true)
 
 deploydocs(
-    repo = "github.com/meggart/Zarr.jl.git",
+    repo = "github.com/JuliaIO/Zarr.jl.git",
 )


### PR DESCRIPTION
The docs have not been deployed since the move to JuliaIO because of the change in the repo url.
This should fix the deployment.