### PR TITLE
Throw more informative error for fill_value=nothing

### DIFF
--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -256,6 +256,9 @@ Read the chunk specified by `i` from the Zarray `z` and write its content to `a`
 """
 function uncompress_raw!(a,z::ZArray{<:Any,N},curchunk) where N
   if curchunk === nothing
+    if isnothing(z.metadata.fill_value) 
+      throw(ArgumentError("The array $z got missing chunks and no fill_value"))
+    end
     fill!(a, z.metadata.fill_value)
   else
     zuncompress!(a, curchunk, z.metadata.compressor, z.metadata.filters)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,6 +257,14 @@ end
     @test all(==(5),c[:,1])
   end
 
+  @testset "Fill_Value nothing with missing chunk" begin
+    # See issue #146
+    p = tempname()
+    a = zcreate(Int64, 10,10,chunks=(5,2))
+    @test_throws ArgumentError a[:,:]
+    
+  end
+
 include("storage.jl")
 
 


### PR DESCRIPTION
This closes Zarr from gdalwarp can not be read because of fill_value is Nothing #146. 