### PR TITLE
Implement ZstdZarrCompressor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,10 +19,14 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 ZipArchives = "49080126-0e18-4c2a-b176-c102e4b3760c"
 
+[weakdeps]
+CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
+
 [compat]
 AWSS3 = "0.10"
 Blosc = "0.5, 0.6, 0.7"
 CodecZlib = "0.6, 0.7"
+CodecZstd = "0.8.3"
 DataStructures = "0.17, 0.18"
 DiskArrays = "0.4.2"
 HTTP = "^1.3"
@@ -33,6 +37,9 @@ OpenSSL = "1"
 URIs = "1"
 ZipArchives = "2"
 julia = "1.2"
+
+[extensions]
+CodecZstdExt = "CodecZstd"
 
 [extras]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -26,8 +26,13 @@ Additional compressors can be loaded via Julia's package extension mechanism.
 For example, the "zstd" compressor ID can be enabled by loading CodecZstd.jl.
 This uses Zstandard directly rather than using Blosc.
 
-```jldoctest
-using Zarr, CodecZstd
-zarray = zzeros(UInt16, 1024, 512, compressor="zstd", path="zarr_zstd_demo")
-zarray2 = zopen("zarr_zstd_demo")
+```julia-repl
+julia> using Zarr, CodecZstd
+
+julia> zarray = zzeros(UInt16, 1024, 512, compressor="zstd", path="zarr_zstd_demo");
+
+julia> zarray2 = zopen("zarr_zstd_demo");
+
+julia> zarray == zarray2
+true
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -20,3 +20,14 @@ Pages = ["ZGroup.jl"]
 Modules = [Zarr]
 Pages = ["Compressors.jl"]
 ```
+
+Additional compressors can be loaded via Julia's package extension mechanism.
+
+For example, the "zstd" compressor ID can be enabled by loading CodecZstd.jl.
+This uses Zstandard directly rather than using Blosc.
+
+```jldoctest
+using Zarr, CodecZstd
+zarray = zzeros(UInt16, 1024, 512, compressor="zstd", path="zarr_zstd_demo")
+zarray2 = zopen("zarr_zstd_demo")
+```

--- a/ext/CodecZstdExt.jl
+++ b/ext/CodecZstdExt.jl
@@ -1,0 +1,56 @@
+module CodecZstdExt
+
+using Zarr: Zarr
+using JSON: JSON
+using CodecZstd: CodecZstd
+
+"""
+    ZstdZarrCompressor(clevel::Int=0)
+    ZstdZarrCompressor(c::CodecZstd.ZstdCompressor, [d::CodecZstd.ZstdDecompressor])
+
+Zstandard compression for Zarr.jl. This is a `Zarr.Compressor` wrapper around
+`CodecZstd`. Construct with either the compression level, `clevel`, or by
+providing an instance of a `ZstdCompressor`.  `ZstdFrameCompressor` is
+recommended.
+"""
+struct ZstdZarrCompressor <: Zarr.Compressor
+    compressor::CodecZstd.ZstdCompressor
+    decompressor::CodecZstd.ZstdDecompressor
+end
+# Use default ZstdDecompressor if only compressor is provided
+function ZstdZarrCompressor(compressor::CodecZstd.ZstdCompressor)
+    return ZstdZarrCompressor(
+        compressor,
+        CodecZstd.ZstdDecompressor()
+    )
+end
+function ZstdZarrCompressor(clevel::Int)
+    return ZstdZarrCompressor(
+        CodecZstd.ZstdFrameCompressor(; level = clevel)
+    )
+end
+ZstdZarrCompressor(;clevel::Int=3) = ZstdZarrCompressor(clevel)
+
+function Zarr.getCompressor(::Type{ZstdZarrCompressor}, d::Dict)
+    return ZstdZarrCompressor(d["level"])
+end
+
+function Zarr.zuncompress(a, z::ZstdZarrCompressor, T)
+    @info "1" a
+    result = transcode(z.decompressor, a)
+    @info "2" result
+    return Zarr._reinterpret(Base.nonmissingtype(T), result)
+end
+
+function Zarr.zcompress(a, z::ZstdZarrCompressor)
+    a_uint8 = Zarr._reinterpret(UInt8,a)[:]
+    transcode(z.compressor, a_uint8)
+end
+
+JSON.lower(z::ZstdZarrCompressor) = Dict("id"=>"zstd", "level" => z.compressor.level)
+
+function __init__()
+    Zarr.compressortypes["zstd"] = ZstdZarrCompressor
+end
+
+end # module CodecZstdExt

--- a/ext/CodecZstdExt.jl
+++ b/ext/CodecZstdExt.jl
@@ -36,9 +36,7 @@ function Zarr.getCompressor(::Type{ZstdZarrCompressor}, d::Dict)
 end
 
 function Zarr.zuncompress(a, z::ZstdZarrCompressor, T)
-    @info "1" a
     result = transcode(z.decompressor, a)
-    @info "2" result
     return Zarr._reinterpret(Base.nonmissingtype(T), result)
 end
 

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -333,6 +333,14 @@ function zcreate(::Type{T},storage::AbstractStore,
   attrs=Dict(),
   writeable=true,
   ) where T
+
+  if compressor isa AbstractString
+    if haskey(compressortypes, String(compressor))
+      compressor = compressortypes[compressor]()
+    else
+      throw(UnknownCompressorException(compressor))
+    end
+  end
   
   length(dims) == length(chunks) || throw(DimensionMismatch("Dims must have the same length as chunks"))
   N = length(dims)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/test/ext.jl
+++ b/test/ext.jl
@@ -9,11 +9,11 @@ using Test
 
     iob = IOBuffer()
     show(iob, Zarr.UnknownCompressorException("zstd"))
-    @test "CodecZstd.jl" ∈ String(take!(iob))
+    @test occursin("CodecZstd.jl", String(take!(iob)))
 
     iob = IOBuffer()
     show(iob, Zarr.UnknownCompressorException("asdf"))
-    @test "issue" ∈ String(take!(iob))
+    @test occursin("issue", String(take!(iob)))
     @test Zarr.getCompressor(nothing) == Zarr.NoCompressor()
 end
 

--- a/test/ext.jl
+++ b/test/ext.jl
@@ -6,6 +6,15 @@ using Test
     @test_throws Zarr.UnknownCompressorException("asdf") zzeros(UInt8, 512, compressor="asdf")
     d = Dict("id" => "zstd")
     @test_throws Zarr.UnknownCompressorException("zstd") Zarr.getCompressor(d)
+
+    iob = IOBuffer()
+    show(iob, Zarr.UnknownCompressorException("zstd"))
+    @test "CodecZstd.jl" ∈ String(take!(iob))
+
+    iob = IOBuffer()
+    show(iob, Zarr.UnknownCompressorException("asdf"))
+    @test "issue" ∈ String(take!(iob))
+    @test Zarr.getCompressor(nothing) == Zarr.NoCompressor()
 end
 
 using CodecZstd

--- a/test/ext.jl
+++ b/test/ext.jl
@@ -3,6 +3,9 @@ using Test
 
 @testset "Zarr Extension Packages" begin
     @test_throws Zarr.UnknownCompressorException("zstd") zzeros(UInt8, 512, compressor="zstd")
+    @test_throws Zarr.UnknownCompressorException("asdf") zzeros(UInt8, 512, compressor="asdf")
+    d = Dict("id" => "zstd")
+    @test_throws Zarr.UnknownCompressorException("zstd") Zarr.getCompressor(d)
 end
 
 using CodecZstd

--- a/test/ext.jl
+++ b/test/ext.jl
@@ -1,0 +1,22 @@
+using Zarr
+using Test
+
+@testset "Zarr Extension Packages" begin
+    @test_throws Zarr.UnknownCompressorException("zstd") zzeros(UInt8, 512, compressor="zstd")
+end
+
+using CodecZstd
+@testset "Zarr CodecZstd Extension" begin
+    CodecZstdExt = Base.get_extension(Zarr, :CodecZstdExt)
+    @test haskey(Zarr.compressortypes, "zstd")
+    @test Zarr.compressortypes["zstd"] == CodecZstdExt.ZstdZarrCompressor
+    td = tempname()
+    zarray = zzeros(UInt16, 16, 16, compressor="zstd", path=td)
+    zarray .= reshape(1:256,16,16)
+    @test isa(zarray, ZArray{UInt16})
+    @test zarray.metadata.compressor isa CodecZstdExt.ZstdZarrCompressor
+    zarray2 = zopen(td)
+    @test isa(zarray2, ZArray{UInt16})
+    @test zarray2.metadata.compressor isa CodecZstdExt.ZstdZarrCompressor
+    @test zarray2 == reshape(1:256,16,16)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -266,9 +266,7 @@ end
   end
 
 include("storage.jl")
-
-
-
 include("python.jl")
+include("ext.jl")
 
 end  # @testset "Zarr"


### PR DESCRIPTION
This implements ZstdZarrCompressor which wraps around CodecZstd as a package extension.

Part of the complication of using package extensions is getting a reference to new types defined in the extension. I created a mechanism by which you could specify the compressor as a string, which would then lookup the type from a dictionary.

I'm also wondering if there might be a general way to wrap TranscodingStreams codecs into Zarr compressors.
