### PR TITLE
open groups lazily

### DIFF
--- a/src/ZGroup.jl
+++ b/src/ZGroup.jl
@@ -44,7 +44,22 @@ function zopen_noerr(s::AbstractStore, mode="r";
     end
 end
 
-Base.show(io::IO, g::ZGroup) = print(io, "ZarrGroup at ", g.storage, " and path ", g.path)
+function Base.show(io::IO, g::ZGroup)
+    print(io, "ZarrGroup at ", g.storage, " and path ", g.path)
+    for (i, d) in enumerate(subdirs(g.storage, g.path))
+        if i > 10  # don't print too many
+            print(io, "\n  ...")
+            break
+        end
+        path = _concatpath(g.path, d)
+        if is_zarray(g.storage, path)
+            print(io, "\n  ", d, " (Array)")
+        elseif is_zgroup(g.storage, path)
+            print(io, "\n  ", d, " (Group)")
+        end
+    end
+end
+
 function Base.haskey(g::ZGroup, k)
     path = _concatpath(g.path, k)
     is_zarray(g.storage, path) || is_zgroup(g.storage, path)

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -176,7 +176,7 @@ end
   @test storagesize(S3,p) == 0
   @test Zarr.is_zgroup(S3,p) == true
   S3group = zopen(S3,path=p)
-  S3Array = S3group.groups["bar"].arrays["baz"]
+  S3Array = S3group["bar"]["baz"]
   @test eltype(S3Array) == Zarr.ASCIIChar
   @test storagesize(S3Array) == 69
   @test String(S3Array[:]) == "Hello from the cloud!"


### PR DESCRIPTION
Currently, `ZGroup` opens a group immediately and recursively, which causes performance issues, especially when the group contains a large number of subarrays or subgroups. For example, in my benchmark, a single `zopen` call to open a group with 100k subarrays took 13 seconds, while a group with 1m subarrays took 266 seconds. This is a cost we want to avoid when we are only interested in a subset of those subarrays.

https://github.com/JuliaIO/Zarr.jl/blob/e3ccc9d82b20a4efeef7734d98c610ece3e0f9f3/src/ZGroup.jl#L17-L33

This PR introduces lazy group opening, meaning `zopen` now opens only the target group without recursively opening subarrays or subgroups. Subarrays and subgroups are opened on demand through `getindex`/`setindex!`. This change significantly improves performance in the scenarios mentioned above.
