### PR TITLE
add complex fill value decoding

### DIFF
--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -218,3 +218,4 @@ fill_value_decoding(v::Nothing, ::Any) = v
 fill_value_decoding(v, T) = T(v)
 fill_value_decoding(v::Number, T::Type{String}) = v == 0 ? "" : T(UInt8[v])
 fill_value_decoding(v, ::Type{ASCIIChar}) = v == "" ? nothing : v
+fill_value_decoding(v::Vector, T::Type{<:Complex}) = T(v[1], v[2])


### PR DESCRIPTION
Complex arrays can end up specifying a fill value of Any[0.0, 0.0], which needs to be converted into the appropriate complex number.