### PR TITLE
Import UInt8 from Base explicitely

### DIFF
--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -1,5 +1,6 @@
+import Base: UInt8
 import Dates: Date, DateTime
-using DateTimes64: DateTime64, pydatetime_string, datetime_from_pystring 
+using DateTimes64: DateTime64, pydatetime_string, datetime_from_pystring
 
 """NumPy array protocol type string (typestr) format
 


### PR DESCRIPTION
This is to silence the warnings on Julia nightly:

```julia
 │  WARNING: Constructor for type "UInt8" was extended in `Zarr` without explicit qualification or import.
│    NOTE: Assumed "UInt8" refers to `Base.UInt8`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function UInt8 end`.
│    Hint: To silence the warning, qualify `UInt8` as `Base.UInt8` or explicitly `import Base: UInt8`
```