### PR TITLE
Add fill_value_decoding method for disambiguation

### DIFF
--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -224,6 +224,7 @@ fill_value_decoding(v::Nothing, ::Any) = v
 fill_value_decoding(v, T) = T(v)
 fill_value_decoding(v::Number, T::Type{String}) = v == 0 ? "" : T(UInt8[v])
 fill_value_decoding(v, ::Type{ASCIIChar}) = v == "" ? nothing : v
+fill_value_decoding(v::Nothing, ::Type{Zarr.ASCIIChar}) = v
 # Sometimes when translating between CF (climate and forecast) convention data
 # and Zarr groups, fill values are left as "negative integers" to encode unsigned
 # integers.  So, we have to convert to the signed type with the same number of bytes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,6 +147,7 @@ end
         @test Zarr.fill_value_decoding("-", String) === "-"
         @test Zarr.fill_value_decoding("", Zarr.ASCIIChar) === nothing
         @test Zarr.fill_value_decoding("", Zarr.MaxLengthString{6,UInt8}) === Zarr.MaxLengthString{6,UInt8}("")
+        @test Zarr.fill_value_decoding(nothing, Zarr.ASCIICHar) === nothing
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,7 +147,7 @@ end
         @test Zarr.fill_value_decoding("-", String) === "-"
         @test Zarr.fill_value_decoding("", Zarr.ASCIIChar) === nothing
         @test Zarr.fill_value_decoding("", Zarr.MaxLengthString{6,UInt8}) === Zarr.MaxLengthString{6,UInt8}("")
-        @test Zarr.fill_value_decoding(nothing, Zarr.ASCIICHar) === nothing
+        @test Zarr.fill_value_decoding(nothing, Zarr.ASCIIChar) === nothing
     end
 end
 


### PR DESCRIPTION
This fixes the error I got in https://github.com/EOPF-Sample-Service/PMP/issues/138. 
All other methods should not be ambiguous. 
