### PR TITLE
Fix reading complex type and add basic round trip test

### DIFF
--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -44,7 +44,6 @@ const typemap = Dict{Tuple{Char, Int}, DataType}(
     ('U', 1) => Char,
 )
 sizemapf(x::Type{<:Number}) = sizeof(x)
-sizemapf(x::Type{<:Complex{T}}) where T = sizeof(T)
 typecharf(::Type{<:Signed}) = 'i'
 typecharf(::Type{<:Unsigned}) = 'u'
 typecharf(::Type{<:AbstractFloat}) = 'f'

--- a/test/python.jl
+++ b/test/python.jl
@@ -32,6 +32,10 @@ numeric_dtypes = (UInt8, UInt16, UInt32, UInt64,
 dtypes = (numeric_dtypes...,
     MaxLengthString{10,UInt8},MaxLengthString{10,UInt32},
     String)
+dtypesp = ("uint8","uint16","uint32","uint64",
+    "int8","int16","int32","int64",
+    "float16","float32","float64",
+    "complex64", "complex128","bool","S10","U10", "O")
 compressors = (
     "no"=>NoCompressor(),
     "blosc"=>BloscCompressor(cname="zstd"),
@@ -79,6 +83,20 @@ open(pjulia*".zip";write=true) do io
     Zarr.writezip(io, g)
 end
 
+@testset "reading in julia" begin
+    g = zopen(pjulia)
+    #Test group attributes
+    @test g.attrs == groupattrs
+    for i=1:length(dtypes), co in compressors
+        compstr,comp = co
+        t = dtypes[i]
+        arname = string("a",t,compstr)
+        ar=g[arname]
+        @test ar.attrs == Dict("This is a nested attribute"=>Dict("a"=>5))
+        @test ar == testarrays[t]
+    end
+end
+
 # Test reading in python
 for julia_path in (pjulia, pjulia*".zip")
     g = zarr.open_group(julia_path)
@@ -88,11 +106,6 @@ for julia_path in (pjulia, pjulia*".zip")
     @test gatts["String attribute"] == "One"
     @test gatts["Int attribute"] == 5
     @test gatts["Float attribute"] == 10.5
-
-    dtypesp = ("uint8","uint16","uint32","uint64",
-        "int8","int16","int32","int64",
-        "float16","float32","float64",
-        "complex64", "complex128","bool","S10","U10", "O")
 
     #Test accessing arrays from python and reading data
     for i=1:length(dtypes), co in compressors


### PR DESCRIPTION
This PR adds some basic round trip tests, which caught a bug in how complex numbers are read.

The `test/python.jl` file tests that `zarr-python` is able to read data from `Zarr.jl`. This PR adds some tests that `Zarr.jl` is able to read data from `Zarr.jl`.