### PR TITLE
Add dimension separator as a type parameter

### DIFF
--- a/src/Storage/consolidated.jl
+++ b/src/Storage/consolidated.jl
@@ -3,18 +3,19 @@ A store that wraps any other AbstractStore but has access to the consolidated me
 stored in the .zmetadata key. Whenever data attributes or metadata are accessed, the
 data will be read from the dictionary instead.
 """
-struct ConsolidatedStore{P} <: AbstractStore
+struct ConsolidatedStore{S,P} <: AbstractStore{S}
   parent::P
   path::String
   cons::Dict{String,Any}
 end
-function ConsolidatedStore(s::AbstractStore, p)
+function ConsolidatedStore{S}(s::AbstractStore, p) where S
   d = s[p, ".zmetadata"]
   if d === nothing
     throw(ArgumentError("Could not find consolidated metadata for store $s"))
   end
-  ConsolidatedStore(s,p,JSON.parse(String(Zarr.maybecopy(d)))["metadata"])
+  ConsolidatedStore{S, typeof(s)}(s,p,JSON.parse(String(Zarr.maybecopy(d)))["metadata"])
 end
+ConsolidatedStore(s::AbstractStore, p) = ConsolidateStore{'.'}(s, p)
 
 function Base.show(io::IO,d::ConsolidatedStore)
     b = IOBuffer()

--- a/src/Storage/dictstore.jl
+++ b/src/Storage/dictstore.jl
@@ -1,8 +1,9 @@
 # Stores data in a simple dict in memory
-struct DictStore <: AbstractStore
+struct DictStore{S} <: AbstractStore{S}
   a::Dict{String,Vector{UInt8}}
 end
-DictStore() = DictStore(Dict{String,Vector{UInt8}}())
+DictStore() = DictStore{'.'}(Dict{String,Vector{UInt8}}())
+DictStore{S}() where S = DictStore{S}(Dict{String,Vector{UInt8}}())
 
 Base.show(io::IO,d::DictStore) = print(io,"Dictionary Storage")
 function _pdict(d::DictStore,p) 

--- a/src/Storage/directorystore.jl
+++ b/src/Storage/directorystore.jl
@@ -9,12 +9,13 @@ function normalize_path(p::AbstractString)
 end
 
 # Stores files in a regular file system
-struct DirectoryStore <: AbstractStore
+struct DirectoryStore{S} <: AbstractStore{S}
     folder::String
-    function DirectoryStore(p)
+    function DirectoryStore{S}(p) where S
       mkpath(normalize_path(p))
-      new(normalize_path(p))
+      new{S}(normalize_path(p))
     end
+    DirectoryStore(p) = DirectoryStore{'.'}(p)
 end
 
 function Base.getindex(d::DirectoryStore, i::String)

--- a/src/Storage/gcstore.jl
+++ b/src/Storage/gcstore.jl
@@ -56,10 +56,10 @@ function _gcs_request_headers()
   return headers
 end
 
-struct GCStore <: AbstractStore
+struct GCStore{S} <: AbstractStore{S}
   bucket::String
 
-  function GCStore(url::String)
+  function GCStore{S}(url::String) where S
     uri = URI(url)
 
     if uri.scheme == "gs"
@@ -71,6 +71,7 @@ struct GCStore <: AbstractStore
     @debug "GCS bucket: $bucket"
     new(bucket)
   end
+  GCStore(url::String) = GCStore{'.'}(url)
 end
 
 

--- a/src/Storage/http.jl
+++ b/src/Storage/http.jl
@@ -10,11 +10,12 @@ datasets being served through the [xpublish](https://xpublish.readthedocs.io/en/
 python package. In case you experience performance issues, one can try to use 
 `HTTP.set_default_connection_limit!` to increase the number of concurrent connections. 
 """
-struct HTTPStore <: AbstractStore
+struct HTTPStore{S} <: AbstractStore{S}
     url::String
     allowed_codes::Set{Int}
+    HTTPStore{S}(url, allowed_codes = Set((404,))) where S = new{S}(url, allowed_codes)
 end
-HTTPStore(url) = HTTPStore(url,Set((404,)))
+HTTPStore(url) = HTTPStore{'.'}(url)
 
 function Base.getindex(s::HTTPStore, k::String)
 r = HTTP.request("GET",string(s.url,"/",k),status_exception = false,socket_type_tls=OpenSSL.SSLStream)

--- a/src/Storage/s3store.jl
+++ b/src/Storage/s3store.jl
@@ -1,19 +1,21 @@
 using AWSS3: AWSS3, s3_put, s3_get, s3_delete, s3_list_objects, s3_exists
 
-struct S3Store <: AbstractStore
+struct S3Store{S} <: AbstractStore{S}
     bucket::String
     aws::AWSS3.AWS.AbstractAWSConfig
 end
 
 
-function S3Store(bucket::String;
+function S3Store{S}(bucket::String;
     aws = nothing,
-  )
+  ) where S
   if aws === nothing
     aws = AWSS3.AWS.global_aws_config()
   end
   S3Store(bucket, aws)
 end
+S3Store(bucket, aws) = S3Store{'.'}(bucket, aws)
+S3Store(bucket; aws = nothing) = S3Store{'.'}(bucket, aws)
 
 Base.show(io::IO,::S3Store) = print(io,"S3 Object Storage")
 

--- a/src/Storage/zipstore.jl
+++ b/src/Storage/zipstore.jl
@@ -5,12 +5,12 @@ import ZipArchives
 
 A read only store that wraps an `AbstractVector{UInt8}` that contains a zip file.
 """
-struct ZipStore{T <: AbstractVector{UInt8}} <: AbstractStore
+struct ZipStore{S, T <: AbstractVector{UInt8}} <: AbstractStore{S}
     r::ZipArchives.ZipBufferReader{T}
+    ZipStore{S}(data::AbstractVector{UInt8}) where S = new{S, ZipArchives.ZipBufferReader}(ZipArchives.ZipBufferReader(data))
 end
 
-
-ZipStore(data::AbstractVector{UInt8}) = ZipStore(ZipArchives.ZipBufferReader(data))
+ZipStore(data::AbstractVector{UInt8}) = ZipStore{'.'}(ZipArchives.ZipBufferReader(data))
 
 Base.show(io::IO,::ZipStore) = print(io,"Read Only Zip Storage")
 

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -91,9 +91,18 @@ Each array requires essential configuration metadata to be stored, enabling corr
 interpretation of the stored data. This metadata is encoded using JSON and stored as the
 value of the “.zarray” key within an array store.
 
+# Type Parameters
+* T - element type of the array
+* N - dimensionality of the array
+* C - compressor
+* F - filters
+* S - dimension separator
+
+# See Also
+
 https://zarr.readthedocs.io/en/stable/spec/v2.html#metadata
 """
-struct Metadata{T, N, C, F}
+struct Metadata{T, N, C, F, S}
     zarr_format::Int
     shape::Base.RefValue{NTuple{N, Int}}
     chunks::NTuple{N, Int}
@@ -102,15 +111,46 @@ struct Metadata{T, N, C, F}
     fill_value::Union{T, Nothing}
     order::Char
     filters::F  # not yet supported
-    function Metadata{T2, N, C, F}(zarr_format, shape, chunks, dtype, compressor,fill_value, order, filters) where {T2,N,C,F}
+    function Metadata{T2, N, C, F, S}(zarr_format, shape, chunks, dtype, compressor, fill_value, order, filters) where {T2,N,C,F,S}
         #We currently only support version 
         zarr_format == 2 || throw(ArgumentError("Zarr.jl currently only support v2 of the protocol"))
         #Do some sanity checks to make sure we have a sane array
         any(<(0), shape) && throw(ArgumentError("Size must be positive"))
         any(<(1), chunks) && throw(ArgumentError("Chunk size must be >= 1 along each dimension"))
         order === 'C' || throw(ArgumentError("Currently only 'C' storage order is supported"))
-        new{T2, N, C, F}(zarr_format, Base.RefValue{NTuple{N,Int}}(shape), chunks, dtype, compressor,fill_value, order, filters)
+        new{T2, N, C, F, S}(zarr_format, Base.RefValue{NTuple{N,Int}}(shape), chunks, dtype, compressor,fill_value, order, filters)
     end
+    function Metadata{T2, N, C, F}(
+        zarr_format,
+        shape,
+        chunks,
+        dtype,
+        compressor,
+        fill_value,
+        order,
+        filters,
+        dimension_separator::Char = '.'
+    ) where {T2,N,C,F}
+        return Metadata{T2, N, C, F, dimension_separator}(
+            zarr_format,
+            shape,
+            chunks,
+            dtype,
+            compressor,
+            fill_value,
+            order 
+        )
+    end
+
+end
+
+const DimensionSeparatedMetadata{S} = Metadata{<: Any, <: Any, <: Any, <: Any, S}
+
+function Base.getproperty(m::DimensionSeparatedMetadata{S}, name::Symbol) where S
+    if name == :dimension_separator
+        return S
+    end
+    return getfield(m, name)
 end
 
 #To make unit tests pass with ref shape
@@ -123,7 +163,8 @@ function ==(m1::Metadata, m2::Metadata)
   m1.compressor == m2.compressor &&
   m1.fill_value == m2.fill_value &&
   m1.order == m2.order &&
-  m1.filters == m2.filters
+  m1.filters == m2.filters &&
+  m1.dimension_separator == m2.dimension_separator
 end
 
 
@@ -135,9 +176,10 @@ function Metadata(A::AbstractArray{T, N}, chunks::NTuple{N, Int};
         order::Char='C',
         filters::Nothing=nothing,
         fill_as_missing = false,
+        dimension_separator::Char = '.'
     ) where {T, N, C}
     T2 = (fill_value === nothing || !fill_as_missing) ? T : Union{T,Missing}
-    Metadata{T2, N, C, typeof(filters)}(
+    Metadata{T2, N, C, typeof(filters), dimension_separator}(
         zarr_format,
         size(A),
         chunks,
@@ -175,7 +217,9 @@ function Metadata(d::AbstractDict, fill_as_missing)
 
     TU = (fv === nothing || !fill_as_missing) ? T : Union{T,Missing}
 
-    Metadata{TU, N, C, F}(
+    S = only(get(d, "dimension_separator", '.'))
+
+    Metadata{TU, N, C, F, S}(
         d["zarr_format"],
         NTuple{N, Int}(d["shape"]) |> reverse,
         NTuple{N, Int}(d["chunks"]) |> reverse,
@@ -197,7 +241,8 @@ function JSON.lower(md::Metadata)
         "compressor" => md.compressor,
         "fill_value" => fill_value_encoding(md.fill_value),
         "order" => md.order,
-        "filters" => md.filters
+        "filters" => md.filters,
+        "dimension_separator" => md.dimension_separator
     )
 end
 


### PR DESCRIPTION
This replaces https://github.com/JuliaIO/Zarr.jl/pull/150 by implementing the dimension_separator as a type 
parameter.

I also intend to add Zarr specification version as a type parameter in forthcoming commits.
