### PR TITLE
Test against julia pre

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,7 @@ jobs:
         version:
           - '1'
           - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
This should test Zarr.jl on the current prerelease which at the moment would be 1.12 beta. 
@mkitti This is what you just requested during our meeting. 

This would close #184 