### PR TITLE
Overload Base.UInt8 explicitly

### DIFF
--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -17,7 +17,7 @@ using .MaxLengthStrings: MaxLengthString
 primitive type ASCIIChar <: AbstractChar 8 end
 ASCIIChar(x::UInt8) = reinterpret(ASCIIChar, x)
 ASCIIChar(x::Integer) = ASCIIChar(UInt8(x))
-UInt8(x::ASCIIChar) = reinterpret(UInt8, x)
+Base.UInt8(x::ASCIIChar) = reinterpret(UInt8, x)
 Base.codepoint(x::ASCIIChar) = UInt8(x)
 Base.show(io::IO, x::ASCIIChar) = print(io, Char(x))
 Base.zero(::Union{ASCIIChar,Type{ASCIIChar}}) = ASCIIChar(Base.zero(UInt8))


### PR DESCRIPTION
This would hopefully get rid of the following warning in julia 1.12

```julia
 ┌ Zarr
│  WARNING: Constructor for type "UInt8" was extended in `Zarr` without explicit qualification or import.
│    NOTE: Assumed "UInt8" refers to `Base.UInt8`. This behavior is deprecated and may differ in future versions.`
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function UInt8 end`.
│    Hint: To silence the warning, qualify `UInt8` as `Base.UInt8` in the method signature or explicitly `import Base: UInt8`.
└  
```