### PR TITLE
Changed sum(.) to reduce(., init=0) in storagesize functions

### DIFF
--- a/src/Storage/dictstore.jl
+++ b/src/Storage/dictstore.jl
@@ -10,7 +10,7 @@ function _pdict(d::DictStore,p)
   filter(((k,v),)->startswith(k,p),d.a)
 end
 function storagesize(d::DictStore,p) 
-  sum(i->last(split(i[1],'/')) ∉ (".zattrs",".zarray") ? sizeof(i[2]) : zero(sizeof(i[2])), _pdict(d,p))
+  reduce((acc,i) -> acc + (last(split(i[1],'/')) ∉ (".zattrs",".zarray") ? sizeof(i[2]) : zero(sizeof(i[2]))), _pdict(d,p); init=0)
 end
 
 function Base.getindex(d::DictStore,i::AbstractString) 

--- a/src/Storage/dictstore.jl
+++ b/src/Storage/dictstore.jl
@@ -10,7 +10,7 @@ function _pdict(d::DictStore,p)
   filter(((k,v),)->startswith(k,p),d.a)
 end
 function storagesize(d::DictStore,p) 
-  sum(i -> acc + (last(split(i[1],'/')) ∉ (".zattrs",".zarray") ? sizeof(i[2]) : zero(sizeof(i[2]))), _pdict(d,p); init=0)
+  sum(i -> (last(split(i[1],'/')) ∉ (".zattrs",".zarray") ? sizeof(i[2]) : zero(sizeof(i[2]))), _pdict(d,p); init=0)
 end
 
 function Base.getindex(d::DictStore,i::AbstractString) 

--- a/src/Storage/dictstore.jl
+++ b/src/Storage/dictstore.jl
@@ -10,7 +10,7 @@ function _pdict(d::DictStore,p)
   filter(((k,v),)->startswith(k,p),d.a)
 end
 function storagesize(d::DictStore,p) 
-  reduce((acc,i) -> acc + (last(split(i[1],'/')) ∉ (".zattrs",".zarray") ? sizeof(i[2]) : zero(sizeof(i[2]))), _pdict(d,p); init=0)
+  sum(i -> acc + (last(split(i[1],'/')) ∉ (".zattrs",".zarray") ? sizeof(i[2]) : zero(sizeof(i[2]))), _pdict(d,p); init=0)
 end
 
 function Base.getindex(d::DictStore,i::AbstractString) 

--- a/src/Storage/directorystore.jl
+++ b/src/Storage/directorystore.jl
@@ -36,7 +36,7 @@ end
 
 
 function storagesize(d::DirectoryStore,p) 
-    reduce((acc,f) -> acc + filesize(d.folder * "/" * p * "/" * f), filter(i->i ∉ (".zattrs",".zarray"),readdir(d.folder * "/" * p)); init=0)
+    sum(f -> filesize(d.folder * "/" * p * "/" * f), filter(i->i ∉ (".zattrs",".zarray"),readdir(d.folder * "/" * p)); init=0)
 end
 
 function subdirs(s::DirectoryStore,p) 

--- a/src/Storage/directorystore.jl
+++ b/src/Storage/directorystore.jl
@@ -35,9 +35,8 @@ function Base.setindex!(d::DirectoryStore,v,i::String)
 end
 
 
-storagesize(d::DirectoryStore,p) = sum(filter(i->i ∉ (".zattrs",".zarray"),readdir(d.folder * "/" * p))) do f
-  fname = d.folder * "/" * p * "/" * f
-  filesize(fname)
+function storagesize(d::DirectoryStore,p) 
+    reduce((acc,f) -> acc + filesize(d.folder * "/" * p * "/" * f), filter(i->i ∉ (".zattrs",".zarray"),readdir(d.folder * "/" * p)); init=0)
 end
 
 function subdirs(s::DirectoryStore,p) 


### PR DESCRIPTION
Fixes #197

Changed storagesize implementation for DirectoryStore so it doesn't break when no chunks are initialized by replacing sum(.) with reduce(., init=0). Also changed DictStore implementation to match even though it was technically not broken before.