### PR TITLE
Enable ZArray with eltype Char

### DIFF
--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -143,6 +143,7 @@ _zero(T) = zero(T)
 _zero(T::Type{<:MaxLengthString}) = T("")
 _zero(T::Type{ASCIIChar}) = ASCIIChar(0)
 _zero(::Type{<:Vector{T}}) where T = T[]
+_zero(::Type{Char}) = Char(0)
 getchunkarray(z::ZArray) = fill(_zero(eltype(z)), z.metadata.chunks)
 
 maybeinner(a::Array) = a

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -214,14 +214,18 @@ end
   @test_throws ArgumentError resize!(a,(-1,2))
 end
 
-@testset "string array getindex/setindex" begin
+@testset "string/Char array getindex/setindex" begin
   aa = ["this", "is", "all ", "ascii"]
   bb = ["And" "Unicode"; "ματριξ" missing]
+  cc = 'A':'D'
   a = ZArray(aa)
   b = ZArray(bb, fill_value = "")
+  c = ZArray(cc)
   @test eltype(a) == String
   @test eltype(b) == Union{String,Missing}
+  @test eltype(c) == Char
   @test a[:] == ["this", "is", "all ", "ascii"]
+  @test c[:] == 'A':'D'
   @test all(isequal.(b[:,:],["And" "Unicode"; "ματριξ" missing]))
 end
 


### PR DESCRIPTION
This adds the _zero function for Char so that we can construct ZArrays with eltype Char even when there are no given fill_value.