### PR TITLE
Fix dtype strings for single-byte types to use '|' byte order

### DIFF
--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -24,11 +24,15 @@ Base.zero(::Union{ASCIIChar,Type{ASCIIChar}}) = ASCIIChar(Base.zero(UInt8))
 
 Base.zero(t::Union{String, Type{String}}) = ""
 
+# Helper function to determine byte order marker
+# Single-byte types use '|' (no byte order), multi-byte types use '<' (little-endian)
+byteorder_marker(t::Type) = sizeof(t) == 1 ? '|' : '<'
+
 typestr(t::Type) = string('<', 'V', sizeof(t))
 typestr(t::Type{>:Missing}) = typestr(Base.nonmissingtype(t))
-typestr(t::Type{Bool}) = string('<', 'b', sizeof(t))
-typestr(t::Type{<:Signed}) = string('<', 'i', sizeof(t))
-typestr(t::Type{<:Unsigned}) = string('<', 'u', sizeof(t))
+typestr(t::Type{Bool}) = string(byteorder_marker(t), 'b', sizeof(t))
+typestr(t::Type{<:Signed}) = string(byteorder_marker(t), 'i', sizeof(t))
+typestr(t::Type{<:Unsigned}) = string(byteorder_marker(t), 'u', sizeof(t))
 typestr(t::Type{Complex{T}} where T<:AbstractFloat) = string('<', 'c', sizeof(t))
 typestr(t::Type{<:AbstractFloat}) = string('<', 'f', sizeof(t))
 typestr(::Type{MaxLengthString{N,UInt32}}) where N = string('<', 'U', N)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,8 +96,12 @@ end
 
 @testset "Metadata" begin
     @testset "Data type encoding" begin
-        @test Zarr.typestr(Bool) === "<b1"
-        @test Zarr.typestr(Int8) === "<i1"
+        # Single-byte types - must use '|' prefix (no byte order)
+        @test Zarr.typestr(Bool) === "|b1"
+        @test Zarr.typestr(Int8) === "|i1"
+        @test Zarr.typestr(UInt8) === "|u1"
+
+        # Multi-byte types - use '<' prefix (little-endian)
         @test Zarr.typestr(Int64) === "<i8"
         @test Zarr.typestr(UInt32) === "<u4"
         @test Zarr.typestr(UInt128) === "<u16"


### PR DESCRIPTION
This PR is a fix of #214. 

Single-byte types (Bool, Int8, UInt8) were incorrectly using '<' (little-endian) byte order marker in their dtype strings. Single-byte types should use '|' (no   byte order) since byte order is irrelevant for single-byte values.