### PR TITLE
Use CondaPkg.jl#206 for nightly, fix manifest_uuid_path

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -13,4 +13,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zarr = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 
 [sources]
+CondaPkg = {rev = "manifest-check", url = "https://github.com/JamesWrigley/CondaPkg.jl"}
 Zarr = {path = ".."}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,12 +5,6 @@ using JSON: json
 using Pkg
 using Dates
 
-if !isdefined(Base, :manifest_uuid_path)
-    # Fixes nightly as of 2026-03-08
-    # https://github.com/JuliaPy/CondaPkg.jl/pull/206
-    Pkg.add(url="https://github.com/JamesWrigley/CondaPkg.jl", rev="manifest-check")
-end
-
 
 @testset "Zarr" begin
 


### PR DESCRIPTION
Fix nightly CI with

https://github.com/JuliaPy/CondaPkg.jl/pull/206
https://github.com/JamesWrigley/CondaPkg.jl/tree/manifest-check
