### PR TITLE
Add support for S3Path and remove deprecated global_aws_config()

### DIFF
--- a/docs/src/tutorials/s3examples.md
+++ b/docs/src/tutorials/s3examples.md
@@ -12,13 +12,15 @@ account, you can access the dataset without credentials as follows:
 
 ````@example aws
 using Zarr, AWSS3
-AWSS3.global_aws_config(AWSS3.AWS.AWSConfig(creds=nothing, region="us-west-2"))
+cfg = AWSS3.AWS.AWSConfig(creds=nothing, region="us-west-2")
 ````
 
 Then we can directly open a zarr group stored on s3
 
 ````@example aws
-z = zopen("s3://mur-sst/zarr-v1")
+z = AWSS3.AWS.with_aws_config(cfg) do
+  zopen("s3://mur-sst/zarr-v1")
+end
 ````
 
 So we see that the store points to a zarr group with a few arrays
@@ -37,6 +39,12 @@ Or some data
 
 ````@example aws
 v[1:1000,1:1000,1]
+````
+It is also possible to use the `AWS3.S3Path` to open the zarr
+
+````@example aws
+s3_path = S3Path("s3://mur-sst/zarr-v1", config=cfg)
+z = zopen(s3_path)
 ````
 
 ## Accessing CMIP6 data on GCS
@@ -140,15 +148,18 @@ Afterwards we create an new bucket where we can store our data:
 ````julia
 using AWSS3
 cfg = MinioConfig("http://localhost:9005")
-AWSS3.global_aws_config(cfg)
-AWSS3.S3.create_bucket("zarrdata")
+AWSS3.AWS.with_aws_config(cfg) do
+  AWSS3.S3.create_bucket("zarrdata")
+end
 ````
 
 Next we create a new zarr group in the just created bucket:
 
 ````julia
 using Zarr
-g = zgroup(S3Store("zarrdata"),"group_1")
+g = AWSS3.AWS.with_aws_config(cfg) do
+  zgroup(S3Store("zarrdata"),"group_1")
+end
 ````
 
 and a new array inside the group and fill it with some data:

--- a/ext/ZarrAWSS3Ext.jl
+++ b/ext/ZarrAWSS3Ext.jl
@@ -7,9 +7,10 @@ import Zarr:
     cloud_list_objects,
     ConcurrentRead,
     storageregexlist,
-    concurrent_io_tasks
+    concurrent_io_tasks,
+    zopen
 
-using AWSS3: AWSS3, s3_put, s3_get, s3_delete, s3_list_objects, s3_exists
+using AWSS3: AWSS3, s3_put, s3_get, s3_delete, s3_list_objects, s3_exists, S3Path, get_config
 
 include("s3store.jl")
 

--- a/ext/s3store.jl
+++ b/ext/s3store.jl
@@ -2,7 +2,7 @@ function Zarr.S3Store(bucket::String;
     aws = nothing,
   )
   if aws === nothing
-    aws = AWSS3.AWS.global_aws_config()
+    aws = AWSS3.AWS.current_aws_config()
   end
   S3Store(bucket, aws)
 end
@@ -69,7 +69,15 @@ function Zarr.storefromstring(::Type{<:S3Store}, s, _)
   decomp = split(s,"/",keepempty=false)
   bucket = decomp[2]
   path = join(decomp[3:end],"/")
-  S3Store(String(bucket),aws=AWSS3.AWS.global_aws_config()),path
+  S3Store(String(bucket),aws=AWSS3.AWS.current_aws_config()),path
 end
 
 Zarr.store_read_strategy(::S3Store) = ConcurrentRead(concurrent_io_tasks[])
+
+function Zarr.zopen(s::S3Path, mode="r"; kwargs...)
+  decomp = split(string(s),"/",keepempty=false)
+  bucket = decomp[2]
+  path = join(decomp[3:end],"/")
+  store = S3Store(bucket, get_config(s))
+  zopen(store, mode; path=path, kwargs...)
+end

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -201,9 +201,10 @@ end
     s = Minio.Server(joinpath("./",tempname()), address="localhost:9001")
     run(s, wait=false)
     cfg = MinioConfig("http://localhost:9001")
-    AWSS3.global_aws_config(cfg)
-    AWSS3.S3.create_bucket("zarrdata")
-    ds = S3Store("zarrdata")
+    ds = AWSS3.AWS.with_aws_config(cfg) do
+      AWSS3.S3.create_bucket("zarrdata")
+      S3Store("zarrdata")
+    end
     test_store_common(ds)
     @test sprint(show, ds) == "S3 Object Storage"
     kill(s)
@@ -215,8 +216,9 @@ end
 @testset "AWS S3 Storage" begin
   V = Zarr.DV
   @info "Testing AWS S3 storage"
-  AWSS3.AWS.global_aws_config(AWSS3.AWS.AWSConfig(creds=nothing, region="us-west-2"))
-  S3, p = Zarr.storefromstring("s3://mur-sst/zarr-v1")
+  S3, p = AWSS3.AWS.with_aws_config(AWSS3.AWS.AWSConfig(creds=nothing, region="us-west-2")) do
+    Zarr.storefromstring("s3://mur-sst/zarr-v1")
+  end
   @test Zarr.is_zgroup(V, S3, p)
   @test storagesize(S3, p) == 10551
   S3group = zopen(S3,path=p)
@@ -224,6 +226,14 @@ end
   @test eltype(S3Array) == Int64
   @test storagesize(S3Array) == 72184
   @test S3Array[1:5] == [0, 1, 2, 3, 4]
+
+  # test with S3Path
+  s3_path = S3Path("s3://mur-sst/zarr-v1", config=AWSS3.AWS.AWSConfig(creds=nothing, region="us-west-2"))
+  S3group2 = zopen(s3_path)
+  S3Array2 = S3group2["time"]
+  @test eltype(S3Array2) == Int64
+  @test storagesize(S3Array2) == 72184
+  @test S3Array2[1:5] == [0, 1, 2, 3, 4]
 end
 
 @testset "GCS Storage" begin


### PR DESCRIPTION
- Add `zopen` method for `AWS3.S3Path`. 
- Replace `AWSS3.global_aws_config` because of deprecation warnings.