### PR TITLE
fixes U1 str parsing

### DIFF
--- a/src/MaxLengthStrings.jl
+++ b/src/MaxLengthStrings.jl
@@ -5,13 +5,13 @@
 # Maybe this should be moved to FizedSizeStrings.jl,
 #but until then let's keep it here...
 module MaxLengthStrings
-import Base: iterate, lastindex, getindex, sizeof, length, ncodeunits, codeunit, isvalid, read, write, String, print, show
+import Base: iterate, lastindex, getindex, sizeof, length, ncodeunits, codeunit, isvalid, read, write, zero, String, print, show
 export MaxLengthString
 
 struct MaxLengthString{N,T} <: AbstractString
     data::NTuple{N,T}
     function MaxLengthString{N,T}(itr) where {N,T}
-      new(totuple_appendzero(NTuple{N,T},itr))
+      new(_totuple_iterative(NTuple{N,T}, itr))
     end
 end
 import Base: tuple_type_head, tuple_type_tail
@@ -92,4 +92,19 @@ end
 
 print(io::IO, s::MaxLengthString) = print(io, String(s))
 show(io::IO, s::MaxLengthString) = show(io, String(s))
+
+function _totuple_iterative(::Type{NTuple{N,T}}, itr)::NTuple{N,T} where {N,T}
+  data = Vector{T}(undef, N)
+  fill!(data, zero(T))
+  i = 1
+  for v in itr
+    i <= N || error("String is too long to fit into MaxLengthString")
+    data[i] = convert(T, v)
+    i += 1
+  end
+  return Tuple(data)::NTuple{N,T}
+end
+
+zero(::Type{MaxLengthString{N,T}}) where {N,T} = reinterpret(MaxLengthString{N,T}, ntuple(_ -> zero(T), N))
+
 end

--- a/src/MaxLengthStrings.jl
+++ b/src/MaxLengthStrings.jl
@@ -5,7 +5,7 @@
 # Maybe this should be moved to FizedSizeStrings.jl,
 #but until then let's keep it here...
 module MaxLengthStrings
-import Base: iterate, lastindex, getindex, sizeof, length, ncodeunits, codeunit, isvalid, read, write
+import Base: iterate, lastindex, getindex, sizeof, length, ncodeunits, codeunit, isvalid, read, write, String, print, show
 export MaxLengthString
 
 struct MaxLengthString{N,T} <: AbstractString
@@ -42,7 +42,7 @@ function iterate(s::MaxLengthString{N}, i::Int = 1) where N
     return (Char(c), i+1)
 end
 
-lastindex(s::MaxLengthString{N}) where {N} = findlast(!iszero,s.data)
+lastindex(s::MaxLengthString{N}) where {N} = something(findlast(!iszero, s.data), 0)
 
 function getindex(s::MaxLengthString, i::Int)
   checkbounds(s,i)
@@ -51,7 +51,7 @@ end
 
 sizeof(s::MaxLengthString) = sizeof(s.data)
 
-length(s::MaxLengthString) = findlast(!iszero,s.data)
+length(s::MaxLengthString) = something(findlast(!iszero, s.data), 0)
 
 ncodeunits(s::MaxLengthString) = length(s)
 
@@ -71,4 +71,25 @@ end
 function write(io::IO, s::MaxLengthString{N}) where N
     return write(io, Ref(s))
 end
+
+function String(s::MaxLengthString{N,UInt8}) where N
+  n = length(s)
+  data = Vector{UInt8}(undef, n)
+  @inbounds for i in 1:n
+    data[i] = s.data[i]
+  end
+  return String(data)
+end
+
+function String(s::MaxLengthString{N,UInt32}) where N
+  n = length(s)
+  io = IOBuffer()
+  @inbounds for i in 1:n
+    print(io, Char(s.data[i]))
+  end
+  return String(take!(io))
+end
+
+print(io::IO, s::MaxLengthString) = print(io, String(s))
+show(io::IO, s::MaxLengthString) = show(io, String(s))
 end

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -154,7 +154,7 @@ function getchunkarray(z::ZArray{>:Missing})
   a = SenMissArray(inner,z.metadata.fill_value)
 end
 _zero(T) = zero(T)
-_zero(T::Type{<:MaxLengthString}) = T("")
+_zero(T::Type{<:MaxLengthString}) = zero(T)
 _zero(T::Type{ASCIIChar}) = ASCIIChar(0)
 _zero(::Type{<:Vector{T}}) where T = T[]
 _zero(::Type{Char}) = Char(0)

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -70,11 +70,8 @@ function typestr(s::AbstractString, filterlist=nothing)
         end
         isempty(typesize) && throw((ArgumentError("$s is not a valid numpy typestr")))
         tc, ts = first(typecode), parse(Int, typesize)
-        if tc == 'U'
-          return MaxLengthString{ts,UInt32}
-        end
-        if tc == 'S' && ts > 1
-          return MaxLengthString{ts,UInt8}
+        if (tc in ('U','S')) && ts > 1
+            return MaxLengthString{ts,tc=='U' ? UInt32 : UInt8}
         end
         if tc == 'M' && ts == 8
             #We have a datetime64 value

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -43,7 +43,6 @@ const typestr_regex = r"^([<|>])([tbiufcmMOSUV])(\d*)(\[\w+\])?$"
 const typemap = Dict{Tuple{Char, Int}, DataType}(
     ('b', 1) => Bool,
     ('S', 1) => ASCIIChar,
-    ('U', 1) => Char,
 )
 sizemapf(x::Type{<:Number}) = sizeof(x)
 typecharf(::Type{<:Signed}) = 'i'
@@ -71,8 +70,11 @@ function typestr(s::AbstractString, filterlist=nothing)
         end
         isempty(typesize) && throw((ArgumentError("$s is not a valid numpy typestr")))
         tc, ts = first(typecode), parse(Int, typesize)
-        if (tc in ('U','S')) && ts > 1
-          return MaxLengthString{ts,tc=='U' ? UInt32 : UInt8}
+        if tc == 'U'
+          return MaxLengthString{ts,UInt32}
+        end
+        if tc == 'S' && ts > 1
+          return MaxLengthString{ts,UInt8}
         end
         if tc == 'M' && ts == 8
             #We have a datetime64 value

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -70,8 +70,11 @@ function typestr(s::AbstractString, filterlist=nothing)
         end
         isempty(typesize) && throw((ArgumentError("$s is not a valid numpy typestr")))
         tc, ts = first(typecode), parse(Int, typesize)
-        if (tc in ('U','S')) && ts > 1
-            return MaxLengthString{ts,tc=='U' ? UInt32 : UInt8}
+        if tc == 'U'
+            return MaxLengthString{ts,UInt32}
+        end
+        if tc == 'S' && ts > 1
+            return MaxLengthString{ts,UInt8}
         end
         if tc == 'M' && ts == 8
             #We have a datetime64 value

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,6 +108,7 @@ end
         @test Zarr.typestr(Complex{Float64}) === "<c16"
         @test Zarr.typestr(Float16) === "<f2"
         @test Zarr.typestr(Float64) === "<f8"
+        @test Zarr.typestr("<U1") == Zarr.MaxLengthString{1,UInt32}
         @test Zarr.typestr(Zarr.MaxLengthString{5,UInt8}) === "<S5"
         @test Zarr.typestr(Zarr.MaxLengthString{9,UInt32}) === "<U9"
         @test Zarr.typestr(Vector{Int64}) === "|O"
@@ -150,6 +151,7 @@ end
         @test Zarr.fill_value_decoding("-", String) === "-"
         @test Zarr.fill_value_decoding("", Zarr.ASCIIChar) === nothing
         @test Zarr.fill_value_decoding("", Zarr.MaxLengthString{6,UInt8}) === Zarr.MaxLengthString{6,UInt8}("")
+        @test Zarr.fill_value_decoding("", Zarr.MaxLengthString{6,UInt32}) === Zarr.MaxLengthString{6,UInt32}("")
         @test Zarr.fill_value_decoding(nothing, Zarr.ASCIIChar) === nothing
     end
 end
@@ -237,6 +239,18 @@ end
   @test a[:] == ["this", "is", "all ", "ascii"]
   @test c[:] == 'A':'D'
   @test all(isequal.(b[:,:],["And" "Unicode"; "ματριξ" missing]))
+end
+
+@testset "MaxLengthString conversion and display" begin
+  s8 = Zarr.MaxLengthString{5,UInt8}("abc")
+  s32 = Zarr.MaxLengthString{5,UInt32}("Snow")
+  sempty = Zarr.MaxLengthString{5,UInt32}("")
+
+  @test String(s8) == "abc"
+  @test String(s32) == "Snow"
+  @test String(sempty) == ""
+  @test sprint(show, s32) == "\"Snow\""
+  @test sprint(show, sempty) == "\"\""
 end
 
 @testset "ragged arrays" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -241,16 +241,15 @@ end
   @test all(isequal.(b[:,:],["And" "Unicode"; "ματριξ" missing]))
 end
 
-@testset "MaxLengthString conversion and display" begin
-  s8 = Zarr.MaxLengthString{5,UInt8}("abc")
-  s32 = Zarr.MaxLengthString{5,UInt32}("Snow")
-  sempty = Zarr.MaxLengthString{5,UInt32}("")
-
-  @test String(s8) == "abc"
-  @test String(s32) == "Snow"
-  @test String(sempty) == ""
-  @test sprint(show, s32) == "\"Snow\""
-  @test sprint(show, sempty) == "\"\""
+@testset "MaxLengthString large-chunk read path" begin
+  MaxLS = Zarr.MaxLengthString{1024,UInt32}
+  fv = MaxLS("")
+  z_v2 = zcreate(MaxLS, 348; chunks=(18674,), fill_value=fv)
+  @test z_v2[1] == fv
+  @test z_v2[end] == fv
+  z_v3 = zcreate(MaxLS, 348; chunks=(18674,), fill_value=fv, zarr_format=3)
+  @test z_v3[1] == fv
+  @test z_v3[end] == fv
 end
 
 @testset "ragged arrays" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -252,6 +252,18 @@ end
   @test z_v3[end] == fv
 end
 
+@testset "MaxLengthString conversion and display" begin
+    s8 = Zarr.MaxLengthString{5,UInt8}("abc")
+    s32 = Zarr.MaxLengthString{5,UInt32}("Snow")
+    sempty = Zarr.MaxLengthString{5,UInt32}("")
+  
+    @test String(s8) == "abc"
+    @test String(s32) == "Snow"
+    @test String(sempty) == ""
+    @test sprint(show, s32) == "\"Snow\""
+    @test sprint(show, sempty) == "\"\""
+end
+
 @testset "ragged arrays" begin
   z = zcreate(Vector{Float64},2,3)
   a, b, c, d = [1.0,2.0,3.0], [4.0,5.0],[2.0],[2.0,3.0]


### PR DESCRIPTION
fixes #255 

- note that now `lastindex` and `length` (`MaxLengthString`) will return `0` instead of nothing. If this is an issue somewhere else, please chime in @meggart @felixcremer 

fixes #256 
- in order to fix this one I needed also the changes for `lastindex` and `length`, hence I'm pushing the appropriate updates also here.