### PR TITLE
Check whether must_understand is set to false

### DIFF
--- a/src/metadata3.jl
+++ b/src/metadata3.jl
@@ -173,7 +173,11 @@ function Metadata3(d::AbstractDict, fill_as_missing)
         # Optionally they can have attributes
         for key in keys(d)
             if key ∉ ("zarr_format", "node_type", "attributes")
-                throw(ArgumentError("Zarr v3 group metadata cannot have a key called $key"))
+            if d[key]["must_understand"] == false
+                @warn "Zarr v3 group metadata has an unrecognized key called $key with must_understand=false; ignoring"
+            else
+                throw(ArgumentError("Zarr v3 group metadata has an unrecognized key called $key with must_understand=true"))
+            end
             end
         end
 
@@ -201,7 +205,12 @@ function Metadata3(d::AbstractDict, fill_as_missing)
     check_keys(d, mandatory_keys)
     for key in keys(d)
         if key ∉ mandatory_keys && key ∉ optional_keys
-            throw(ArgumentError("Zarr v3 metadata cannot have a key called $key"))
+            if d[key]["must_understand"] === false
+                @warn "Zarr v3 array metadata has an unrecognized key called $key with must_understand=false; ignoring"
+            else                
+                throw(ArgumentError("Zarr v3 array metadata has an unrecognized key called $key with must_understand=true"))
+            end
+            #throw(ArgumentError("Zarr v3 metadata cannot have a key called $key"))
         end
     end
 

--- a/src/metadata3.jl
+++ b/src/metadata3.jl
@@ -153,7 +153,8 @@ function get_order(md::MetadataV3)
 end
 get_order(md::MetadataV2) = md.order
 
-
+must_understand(x) = true # The default of must_understand is true
+must_understand(x::Dict) = get(x, "must_understand", true)
 
 function Metadata3(d::AbstractDict, fill_as_missing)
     check_keys(d, ("zarr_format", "node_type"))
@@ -173,7 +174,7 @@ function Metadata3(d::AbstractDict, fill_as_missing)
         # Optionally they can have attributes
         for key in keys(d)
             if key ∉ ("zarr_format", "node_type", "attributes")
-            if d[key]["must_understand"] == false
+            if !must_understand(d[key])
                 @warn "Zarr v3 group metadata has an unrecognized key called $key with must_understand=false; ignoring"
             else
                 throw(ArgumentError("Zarr v3 group metadata has an unrecognized key called $key with must_understand=true"))

--- a/test/v3_codecs.jl
+++ b/test/v3_codecs.jl
@@ -394,6 +394,9 @@ end
 
     # Extra key in group metadata
     @test_throws ArgumentError Zarr.Metadata("""{"zarr_format":3,"node_type":"group","bad_key":1}""", false)
+    
+    #Extra dict that is ignored
+    @test_warn "ignoring" Zarr.Metadata("""{"zarr_format":3,"node_type":"group","ignore_dict":{"must_understand":false}}""", false) isa Zarr.Metadata
 
     # Missing required key (shape)
     @test_throws ArgumentError Zarr.Metadata("""{"zarr_format":3,"node_type":"array","data_type":"int32",
@@ -406,6 +409,7 @@ end
         "chunk_grid":{"name":"unknown","configuration":{"chunk_shape":[4]}},
         "chunk_key_encoding":{"name":"default","configuration":{"separator":"/"}},
         "fill_value":0,"codecs":[{"name":"bytes","configuration":{"endian":"little"}}]}""", false)
+
 
     # Shape/chunk rank mismatch
     @test_throws ArgumentError Zarr.Metadata("""{"zarr_format":3,"node_type":"array","shape":[4],"data_type":"int32",


### PR DESCRIPTION
If I am understanding the zarr spec correctly metadata entries that contain a must_understand key set to false are discouraged but allowed. https://zarr-specs.readthedocs.io/en/latest/v3/core/index.html#extensions-section

This sets a check whether must_understand is set to false if a key is not in the default keys.
I came across this while working on #254  and on the example data there is a consolidated_metadata field in the attributes which contains a must_understand set to false. 

