### PR TITLE
do not allocate in-memory array just for metadata construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix creation of on-disk arrays that do not fit in memory [#269](https://github.com/JuliaIO/Zarr.jl/pull/269)
+
 ## v0.10.0 - 2026-04-24
 
 - Enable `sharding_indexed` codec for Zarr v3 [#241](https://github.com/JuliaIO/Zarr.jl/pull/241)

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -342,6 +342,8 @@ end
 struct ShapeOnlyArray{T,N} <: AbstractArray{T,N}
     sz::NTuple{N,Int}
 end
+ShapeOnlyArray{T,N}(sz::NTuple{N,<:Integer}) where {T,N} =
+    ShapeOnlyArray{T,N}(ntuple(i -> Int(sz[i]), N))
 Base.size(a::ShapeOnlyArray) = a.sz
 Base.getindex(::ShapeOnlyArray, ::Vararg{Int}) =
     error("ShapeOnlyArray carries no data")

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -343,7 +343,7 @@ struct ShapeOnlyArray{T,N} <: AbstractArray{T,N}
     sz::Dims{N}
 end
 Base.size(a::ShapeOnlyArray) = a.sz
-Base.getindex(::ShapeOnlyArray, ::Vararg{Int}) =
+Base.getindex(::ShapeOnlyArray, ::Vararg{Any}) =
     error("ShapeOnlyArray carries no data")
 
 function zcreate(::Type{T},storage::AbstractStore,

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -342,8 +342,6 @@ end
 struct ShapeOnlyArray{T,N} <: AbstractArray{T,N}
     sz::Dims{N}
 end
-ShapeOnlyArray{T,N}(sz::NTuple{N,<:Integer}) where {T,N} =
-    ShapeOnlyArray{T,N}(ntuple(i -> Int(sz[i]), N))
 Base.size(a::ShapeOnlyArray) = a.sz
 Base.getindex(::ShapeOnlyArray, ::Vararg{Int}) =
     error("ShapeOnlyArray carries no data")

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -340,7 +340,7 @@ function zcreate(::Type{T}, dims::Integer...;
 end
 
 struct ShapeOnlyArray{T,N} <: AbstractArray{T,N}
-    sz::NTuple{N,Int}
+    sz::Dims{N}
 end
 ShapeOnlyArray{T,N}(sz::NTuple{N,<:Integer}) where {T,N} =
     ShapeOnlyArray{T,N}(ntuple(i -> Int(sz[i]), N))

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -339,6 +339,13 @@ function zcreate(::Type{T}, dims::Integer...;
   zcreate(T, store, dims...; zarr_format, dimension_separator, kwargs...)
 end
 
+struct ShapeOnlyArray{T,N} <: AbstractArray{T,N}
+    sz::NTuple{N,Int}
+end
+Base.size(a::ShapeOnlyArray) = a.sz
+Base.getindex(::ShapeOnlyArray, ::Vararg{Int}) =
+    error("ShapeOnlyArray carries no data")
+
 function zcreate(::Type{T},storage::AbstractStore,
   dims...;
   path = "",
@@ -370,7 +377,7 @@ function zcreate(::Type{T},storage::AbstractStore,
   
   # Create a dummy array to use with Metadata constructor
   # This allows us to leverage the multiple dispatch in Metadata constructors
-  dummy_array = Array{T,N}(undef, dims...)
+  dummy_array = ShapeOnlyArray{T,N}(dims)
   metadata = Metadata(dummy_array, chunks, v;
       compressor=compressor,
       fill_value=fill_value,

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -341,6 +341,7 @@ end
 
 struct ShapeOnlyArray{T,N} <: AbstractArray{T,N}
     sz::Dims{N}
+    ShapeOnlyArray{T,N}(dims::Dims{N}) where {T,N} = new{T,N}(dims)
 end
 Base.size(a::ShapeOnlyArray) = a.sz
 Base.getindex(::ShapeOnlyArray, ::Vararg{Any}) =

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -341,7 +341,6 @@ end
 
 struct ShapeOnlyArray{T,N} <: AbstractArray{T,N}
     sz::Dims{N}
-    ShapeOnlyArray{T,N}(dims::Dims{N}) where {T,N} = new{T,N}(dims)
 end
 Base.size(a::ShapeOnlyArray) = a.sz
 Base.getindex(::ShapeOnlyArray, ::Vararg{Any}) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,6 +260,7 @@ end
     mktempdir() do dir
         # Tens of TB if zcreate were materializing dummy storage.
         r = @timed zcreate(UInt8, 10674, 10653, 9327; path = joinpath(dir, "big.zarr"))
+        @test r.bytes < 1e9
         @test size(r.value) == (10674, 10653, 9327)
         @test eltype(r.value) == UInt8
         GC.gc()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -258,7 +258,7 @@ end
 
 @testset "zcreate does not allocate dense storage" begin
     mktempdir() do dir
-        # Tens of TB if zcreate were materializing dummy storage.
+        # About 1 TB if zcreate were materializing dummy storage.
         r = @timed zcreate(UInt8, 10674, 10653, 9327; path = joinpath(dir, "big.zarr"))
         @test r.bytes < 1e9
         @test size(r.value) == (10674, 10653, 9327)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,6 +255,25 @@ end
   @test a[12:13,:]==vcat(singlerow', singlerow')
   @test_throws ArgumentError resize!(a,(-1,2))
 end
+@testset "ShapeOnlyArray" begin
+    A = ShapeOnlyArray{Float64,3}((3,4,5))
+    @test size(A) == (3,4,5)
+    @test eltype(A) == Float64
+    @test_throws ErrorException A[1]
+    @test_throws ErrorException A[1,1,1]
+    @test_throws ErrorException A[-1]
+    
+    B = ShapeOnlyArray{Int8,1}((3,))
+    @test size(B) == (3,)
+    @test eltype(B) == Int8
+    for i in 0:4
+        @test_throws ErrorException B[i]
+    end
+    
+    C = ShapeOnlyArray{Bool,2}((0x2,UInt16(4095)))
+    @test size(C) === (2,4095)
+    @test eltype(C) == Bool
+end
 
 @testset "zcreate does not allocate dense storage" begin
     mktempdir() do dir

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,12 +257,13 @@ end
 end
 
 @testset "zcreate does not allocate dense storage" begin
-    # Tens of TB if zcreate were materializing dummy storage.
-    z = zcreate(UInt8, 10674, 10653, 9327;
-                path = mktempdir() * "/big.zarr",
-                chunks = (256, 256, 256))
-    @test size(z) == (10674, 10653, 9327)
-    @test eltype(z) == UInt8
+    mktempdir() do dir
+        # Tens of TB if zcreate were materializing dummy storage.
+        r = @timed zcreate(UInt8, 10674, 10653, 9327; path = joinpath(dir, "big.zarr"))
+        @test size(r.value) == (10674, 10653, 9327)
+        @test eltype(r.value) == UInt8
+        GC.gc()
+    end
 end
 
 @testset "concatenate" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -256,6 +256,15 @@ end
   @test_throws ArgumentError resize!(a,(-1,2))
 end
 
+@testset "zcreate does not allocate dense storage" begin
+    # Tens of TB if zcreate were materializing dummy storage.
+    z = zcreate(UInt8, 10674, 10653, 9327;
+                path = mktempdir() * "/big.zarr",
+                chunks = (256, 256, 256))
+    @test size(z) == (10674, 10653, 9327)
+    @test eltype(z) == UInt8
+end
+
 @testset "concatenate" begin
     a = zzeros(Int64, 10, 10, chunks = (5,2), fill_value=-1)
     ca = cat(a, a, dims=3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,22 +255,23 @@ end
   @test a[12:13,:]==vcat(singlerow', singlerow')
   @test_throws ArgumentError resize!(a,(-1,2))
 end
+
 @testset "ShapeOnlyArray" begin
-    A = ShapeOnlyArray{Float64,3}((3,4,5))
+    A = Zarr.ShapeOnlyArray{Float64,3}((3,4,5))
     @test size(A) == (3,4,5)
     @test eltype(A) == Float64
     @test_throws ErrorException A[1]
     @test_throws ErrorException A[1,1,1]
     @test_throws ErrorException A[-1]
     
-    B = ShapeOnlyArray{Int8,1}((3,))
+    B = Zarr.ShapeOnlyArray{Int8,1}((3,))
     @test size(B) == (3,)
     @test eltype(B) == Int8
     for i in 0:4
         @test_throws ErrorException B[i]
     end
     
-    C = ShapeOnlyArray{Bool,2}((0x2,UInt16(4095)))
+    C = Zarr.ShapeOnlyArray{Bool,2}((0x2,UInt16(4095)))
     @test size(C) === (2,4095)
     @test eltype(C) == Bool
 end


### PR DESCRIPTION
as it stands now it is impossible to create a Zarr array that won't fit in memory.  because a temporary array is create solely to initialize the metadata.  this PR fixes that by defining an empty array type that has the same eltype and returns the fake size when queried.

the alternative would be to define more Metadata methods, but that's a much more invasive change.

@mkitti 