### PR TITLE
Performance: bulk-copy uncompressed encode + undef chunk buffer

### DIFF
--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -160,6 +160,19 @@ _zero(::Type{<:Vector{T}}) where T = T[]
 _zero(::Type{Char}) = Char(0)
 getchunkarray(z::ZArray) = fill(_zero(eltype(z)), z.metadata.chunks)
 
+# Same as `getchunkarray` but skips the zero/fill_value-fill. Use only
+# when the caller guarantees the buffer will be fully overwritten before
+# any read (e.g. decode-into or full-chunk-write paths).
+#
+# Falls back to the standard `getchunkarray` for `>:Missing` element
+# types: the codec pipeline requires the underlying buffer to be the
+# `isbits` inner of a `SenMissArray`, not an `Array{Union{Missing,T}}`
+# directly (Blosc and friends reject non-isbits eltypes).
+function getchunkarray_undef(z::ZArray{T}) where {T}
+    Missing <: T && return getchunkarray(z)
+    return Array{T}(undef, z.metadata.chunks)
+end
+
 maybeinner(a::Array) = a
 maybeinner(a::SenMissArray) = a.x
 resetbuffer!(fv,a::Array) = fv === nothing || fill!(a,fv)
@@ -168,13 +181,15 @@ resetbuffer!(_,a::SenMissArray) = fill!(a,missing)
 # Function to read or write from a zarr array. Could be refactored
 # using type system to get rid of the `if readmode` statements.
 function readblock!(aout::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::CartesianIndices{N}) where {N}
-  
+
   output_base_offsets = map(i->first(i)-1,r.indices)
   # Determines which chunks are affected
   blockr = CartesianIndices(map(trans_ind, r.indices, z.metadata.chunks))
-  # Allocate array of the size of a chunks where uncompressed data can be held
-  #bufferdict = IdDict((current_task()=>getchunkarray(z),))
-  a = getchunkarray(z)
+  # Allocate the chunk-shaped scratch buffer. Reads always either fill it
+  # from a decode (which writes every element) or fall through to the
+  # fill-value path (which calls `fill!` itself), so we don't need to
+  # pre-zero it.
+  a = getchunkarray_undef(z)
   # Now loop through the chunks
   c = Channel{Pair{eltype(blockr),Union{Nothing,Vector{UInt8}}}}(channelsize(z.storage))
   
@@ -208,9 +223,13 @@ function writeblock!(ain::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::Cartes
   input_base_offsets = map(i->first(i)-1,r.indices)
   # Determines which chunks are affected
   blockr = CartesianIndices(map(trans_ind, r.indices, z.metadata.chunks))
-  # Allocate array of the size of a chunks where uncompressed data can be held
-  #bufferdict = IdDict((current_task()=>getchunkarray(z),))
-  a = getchunkarray(z)
+  # If `fill_value === nothing`, the legacy behaviour is that un-written
+  # cells in a partial-write to a new chunk default to zero (via the
+  # zero-fill of `getchunkarray`). We preserve that by using the
+  # zero-filled buffer when `fill_value` is `nothing`; in the common case
+  # (writer specifies `fill_value`, full-chunk writes), `resetbuffer!`
+  # handles initialisation explicitly and we save the dead memset.
+  a = z.metadata.fill_value === nothing ? getchunkarray(z) : getchunkarray_undef(z)
   # Now loop through the chunks
   readchannel = Channel{Pair{eltype(blockr),Union{Nothing,Vector{UInt8}}}}(channelsize(z.storage))
   

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -1,4 +1,17 @@
 function pipeline_encode(p::V2Pipeline, data::AbstractArray, fill_value)
+    # Fast path: NoCompressor + no filters is just a bulk byte copy. The
+    # generic zcompress! path below funnels through `append!` of a reinterpret
+    # view, which materialises the bytes one element at a time and dominates
+    # CPU for uncompressed writes. We also skip the all-fill-value scan
+    # because (a) it's an O(N) read of the chunk on every write and (b) the
+    # common dense-write use case never benefits.
+    if p.compressor isa NoCompressor && p.filters === nothing
+        n = sizeof(data)
+        out = Vector{UInt8}(undef, n)
+        GC.@preserve out data unsafe_copyto!(pointer(out),
+                                             Ptr{UInt8}(pointer(data)), n)
+        return out
+    end
     if fill_value !== nothing && all(isequal(fill_value), data)
         return nothing
     end


### PR DESCRIPTION
## Summary

Targeted optimisation of the **Zarr v2 uncompressed write path**: ~2.4× speedup on `NoCompressor` writes by replacing an element-wise `append!`-driven byte materialisation with a single `unsafe_copyto!`, and by skipping a redundant zero-fill of the chunk scratch buffer on common paths.

Bytes on disk are bit-identical to current `master`. No public API change.

**Scope note (updated):** the headline fix targets `pipeline_encode(::V2Pipeline, ...)`. The V3 encode path goes through `Codecs.V3Codecs.codec_encode(::BytesCodec, ...)` which already does a bulk `reinterpret(UInt8, vec(data)) |> collect`, so the V2 antipattern this patch fixes doesn't exist in V3. V3 still gains a small amount from the read-side `getchunkarray_undef` change, but the write number is essentially unchanged. The V3 hot path is a separate problem, out of scope for this PR.

## Measured impact

256×256×32 `Float32` chunks × 50 timesteps, single-threaded, `NoCompressor`, Apple M2 Ultra, APFS internal NVMe:

| | V2 write (MiB/s) | V3 write (MiB/s) |
|---|---:|---:|
| Zarr.jl master | 479 | 858 |
| **this patch** | **1137** | 852 |

The V2 fix lands Zarr.jl V2 write throughput at parity with the Rust-backed Zarrs.jl V3 (~1300 MiB/s on the same workload). For users who want the fastest write path today, this PR makes Zarr.jl V2 + `NoCompressor` competitive without a Rust dependency.

Full investigation, profile, and four-way comparison plots (baseline / this patch / Prop B prototype / Zarrs.jl), split by V2 and V3: https://github.com/glwagner/ZarrBenchmarks

## What's in the patch

**`src/pipeline.jl`** — `pipeline_encode(::V2Pipeline, ...)` gains a fast path for `NoCompressor + no filters`:

```julia
if p.compressor isa NoCompressor && p.filters === nothing
    n = sizeof(data)
    out = Vector{UInt8}(undef, n)
    GC.@preserve out data unsafe_copyto!(pointer(out),
                                         Ptr{UInt8}(pointer(data)), n)
    return out
end
```

This bypasses the generic `zcompress!` path, which for `NoCompressor` was funnelling through `append!(compressed, reinterpret(UInt8, data))`. `append!` of a reinterpret view materialises bytes one element at a time through `_growend!` / `push!`, and a flat profile showed this path consuming 67% of V2 write CPU. The new path is a single bulk memcpy.

The fast path also skips the `all(isequal(fill_value), data)` scan, an O(N) walk of the chunk on every write whose purpose is to *avoid* writing all-fill-value chunks. The all-codec fallback path retains that scan, so chunk-elision behaviour for less-common cases is unchanged.

**`src/ZArray.jl`** — adds a `getchunkarray_undef(z)` variant that skips the `fill(_zero(eltype(z)), chunks)` zero-fill. Used in:

- `readblock!`: always safe — the buffer is fully overwritten by `pipeline_decode!` (which `copyto!`s into it) or `fill!` (via `uncompress_raw!`'s fill-value fallback) before any read.
- `writeblock!`: use undef when `fill_value !== nothing` (the `resetbuffer!` path inside the loop handles initialisation explicitly). When `fill_value === nothing` we keep the zero-filled buffer to preserve the legacy "unwritten cells in a partial-chunk write default to zero" behaviour.

`getchunkarray_undef` defers to the original `getchunkarray` for `>:Missing` element types — the codec pipeline requires the buffer to be the `isbits` inner of a `SenMissArray`, not an `Array{Union{Missing,T}}` directly (Blosc and friends reject non-isbits eltypes). The undef fast path applies only to plain isbits eltypes.

## Test plan

- [x] **`Pkg.test("Zarr")` passes: 2593 / 2593** on this branch (with #273 applied to fix the unrelated test-environment instantiation issue).
- [x] Round-trip correctness across `{NoCompressor, ZstdCompressor, BloscCompressor}` × `{fill_value: nothing, zero, NaN}` × `{1D, 2D, 3D, 4D shapes}` × `{Float32, Float64, Int32}`.
- [x] Partial-chunk write preserves the `fill_value === nothing` zero-fallthrough behaviour.
- [x] Bytes-on-disk size matches expected: NoCompressor V2 chunk = exact `length(data) * sizeof(T)`, no overhead.
- [x] `>:Missing` sentinel-value paths verified.

## CI dependency

The CI on this PR currently fails at the pre-test "Generate Julia and Python v3 fixtures" step. **That failure is unrelated to this PR** — `test/Project.toml` pins `CondaPkg` to a branch on `JamesWrigley/CondaPkg.jl` that was deleted upstream between PR #270 (May 8, last passing master CI) and now. #273 fixes it. Once #273 lands I'll rebase, or I'm happy to absorb the `test/Project.toml` change into this PR if that's preferred.

## Followups

The ZarrBenchmarks investigation also identified, in rough order of expected impact:

- `writeblock!` spawns two `@async` tasks via Channels even for single-chunk writes (V2 + V3).
- The read-modify-write `readtask` runs even when overwriting a chunk fully (V2 + V3).
- `pipeline_encode` allocates a fresh `Vector{UInt8}` per chunk for the compressed codec path (V2 + V3).
- **V3-specific:** `BytesCodec.codec_encode` does `reinterpret(...) |> collect` which is bulk-copy fast but still allocates a fresh `Vector{UInt8}` per call — could plumb a scratch buffer through.
- **V3-specific:** `pipeline_decode!` `copyto!(output, arr)`s a final intermediate array; the codec chain could decode in-place into `output` for the common single-codec case.

Each is plausibly 5–15% on its own and they compose. Happy to follow up with separate PRs once this one lands.