### PR TITLE
Performance improvements (v2 only for now)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- V2 writes: add `writeblock!` fast path for single-chunk full-overwrites that bypasses the readtask/writetask channels and the chunk-shaped scratch buffer, encoding straight from the input array into the store [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
 - V2 NoCompressor writes: replace `append!` over the reinterpret view with bulk `resize!` + `copyto!` in the generic `zcompress!` fallback [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
 - V2 NoCompressor reads: add bulk-copy `zuncompress!` method dispatched on `::NoCompressor` to bypass `copyto!(::Array, ::ReinterpretArray)`'s element-by-element walk [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
 - V2 read+write chunk allocation: add `getchunkarray_undef` and skip the dead zero-fill of the chunk-shaped scratch buffer on full-overwrite paths [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- V2 reads: add `readblock!` fast path for single-chunk full-reads that bypasses the readtask channel and the chunk-shaped scratch buffer, decoding straight into the output array [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
 - V2 writes: add `writeblock!` fast path for single-chunk full-overwrites that bypasses the readtask/writetask channels and the chunk-shaped scratch buffer, encoding straight from the input array into the store [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
 - V2 NoCompressor writes: replace `append!` over the reinterpret view with bulk `resize!` + `copyto!` in the generic `zcompress!` fallback [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
 - V2 NoCompressor reads: add bulk-copy `zuncompress!` method dispatched on `::NoCompressor` to bypass `copyto!(::Array, ::ReinterpretArray)`'s element-by-element walk [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
-- V2 reads: add `readblock!` fast path for single-chunk full-reads that bypasses the readtask channel and the chunk-shaped scratch buffer, decoding straight into the output array [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
-- V2 writes: add `writeblock!` fast path for single-chunk full-overwrites that bypasses the readtask/writetask channels and the chunk-shaped scratch buffer, encoding straight from the input array into the store [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
-- V2 NoCompressor writes: replace `append!` over the reinterpret view with bulk `resize!` + `copyto!` in the generic `zcompress!` fallback [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
-- V2 NoCompressor reads: add bulk-copy `zuncompress!` method dispatched on `::NoCompressor` to bypass `copyto!(::Array, ::ReinterpretArray)`'s element-by-element walk [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
-- V2 read+write chunk allocation: add `getchunkarray_undef` and skip the dead zero-fill of the chunk-shaped scratch buffer on full-overwrite paths [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
+- V2 performance improvements [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
+  - `readblock!` fast path for single-chunk full-reads that bypasses the readtask channel and the chunk-shaped scratch buffer, decoding straight into the output array
+  - `writeblock!` fast path for single-chunk full-overwrites that bypasses the readtask/writetask channels and the chunk-shaped scratch buffer, encoding straight from the input array into the store
+  - Zero-copy chunk write for `NoCompressor` + no filters: the single-chunk fastpath hands a `reinterpret(UInt8, ain)` view straight to the store, skipping the chunk-sized `Vector{UInt8}` allocation + memcpy
+  - `NoCompressor` writes: replace `append!` over the reinterpret view with bulk `resize!` + `copyto!` in the generic `zcompress!` fallback
+  - `NoCompressor` reads: bulk-copy `zuncompress!` method dispatched on `::NoCompressor` bypasses `copyto!(::Array, ::ReinterpretArray)`'s element-by-element walk
+  - `getchunkarray_undef` skips the dead zero-fill of the chunk-shaped scratch buffer on full-overwrite paths
 - Fix CondaPkg branch in CI, use release version instead [#273](https://github.com/JuliaIO/Zarr.jl/pull/273)
 - Fix creation of on-disk arrays that do not fit in memory [#269](https://github.com/JuliaIO/Zarr.jl/pull/269)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- V2 NoCompressor writes: replace `append!` over the reinterpret view with bulk `resize!` + `copyto!` in the generic `zcompress!` fallback [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
+- V2 NoCompressor reads: add bulk-copy `zuncompress!` method dispatched on `::NoCompressor` to bypass `copyto!(::Array, ::ReinterpretArray)`'s element-by-element walk [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
+- V2 read+write chunk allocation: add `getchunkarray_undef` and skip the dead zero-fill of the chunk-shaped scratch buffer on full-overwrite paths [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)
 - Fix CondaPkg branch in CI, use release version instead [#273](https://github.com/JuliaIO/Zarr.jl/pull/273)
 - Fix creation of on-disk arrays that do not fit in memory [#269](https://github.com/JuliaIO/Zarr.jl/pull/269)
 

--- a/src/Compressors/Compressors.jl
+++ b/src/Compressors/Compressors.jl
@@ -29,10 +29,17 @@ getCompressor(::Nothing) = NoCompressor()
 zcompress!(compressed,data,c,::Nothing) = zcompress!(compressed,data,c)
 zuncompress!(data,compressed,c,::Nothing) = zuncompress!(data,compressed,c)
 
-# Fallback definition of mutating form of compress and uncompress
-function zcompress!(compressed, data, c) 
-    empty!(compressed)
-    append!(compressed,zcompress(data, c))
+# Fallback definition of mutating form of compress and uncompress.
+# `zcompress(data, c)` may return either a freshly-allocated `Vector{UInt8}`
+# (real compressors) or a lazy `reinterpret` view (`NoCompressor`). For the
+# view case, the old `empty!` + `append!` path walked the view element by
+# element through `_growend!` / `push!`, materialising bytes one at a time;
+# `resize!` + `copyto!` issues a single bulk copy (SIMD / memcpy under the
+# hood) instead.
+function zcompress!(compressed, data, c)
+    src = zcompress(data, c)
+    resize!(compressed, length(src))
+    copyto!(compressed, src)
 end
 zuncompress!(data, compressed, c) = copyto!(data, zuncompress(compressed, c, eltype(data)))
 

--- a/src/Compressors/Compressors.jl
+++ b/src/Compressors/Compressors.jl
@@ -29,13 +29,7 @@ getCompressor(::Nothing) = NoCompressor()
 zcompress!(compressed,data,c,::Nothing) = zcompress!(compressed,data,c)
 zuncompress!(data,compressed,c,::Nothing) = zuncompress!(data,compressed,c)
 
-# Fallback definition of mutating form of compress and uncompress.
-# `zcompress(data, c)` may return either a freshly-allocated `Vector{UInt8}`
-# (real compressors) or a lazy `reinterpret` view (`NoCompressor`). For the
-# view case, the old `empty!` + `append!` path walked the view element by
-# element through `_growend!` / `push!`, materialising bytes one at a time;
-# `resize!` + `copyto!` issues a single bulk copy (SIMD / memcpy under the
-# hood) instead.
+# Bulk `resize!` + `copyto!` (not `append!`): avoids elementwise growth over `NoCompressor`'s view.
 function zcompress!(compressed, data, c)
     src = zcompress(data, c)
     resize!(compressed, length(src))
@@ -79,11 +73,7 @@ function zcompress(a, ::NoCompressor)
   _reinterpret(UInt8,a)
 end
 
-# Fast path: NoCompressor decode is a bulk byte copy. The generic
-# `zuncompress!` fallback at the top of this file ends up at
-# `copyto!(::Array{T}, ::ReinterpretArray)`, which walks element by
-# element at ~17 GB/s on Apple silicon vs. ~85 GB/s for `unsafe_copyto!`.
-# Mirror image of the encode-side bulk copy inside `zcompress!`.
+# Fast path: bulk `unsafe_copyto!` avoids the elementwise `ReinterpretArray` copy of the fallback.
 function zuncompress!(data::Array{T}, compressed::Vector{UInt8}, ::NoCompressor) where {T}
     isbitstype(T) || return copyto!(data, _reinterpret(T, compressed))
     n = sizeof(data)

--- a/src/Compressors/Compressors.jl
+++ b/src/Compressors/Compressors.jl
@@ -79,6 +79,22 @@ function zcompress(a, ::NoCompressor)
   _reinterpret(UInt8,a)
 end
 
+# Fast path: NoCompressor decode is a bulk byte copy. The generic
+# `zuncompress!` fallback at the top of this file ends up at
+# `copyto!(::Array{T}, ::ReinterpretArray)`, which walks element by
+# element at ~17 GB/s on Apple silicon vs. ~85 GB/s for `unsafe_copyto!`.
+# Mirror image of the encode-side bulk copy inside `zcompress!`.
+function zuncompress!(data::Array{T}, compressed::Vector{UInt8}, ::NoCompressor) where {T}
+    isbitstype(T) || return copyto!(data, _reinterpret(T, compressed))
+    n = sizeof(data)
+    n == length(compressed) || throw(DimensionMismatch(
+        "Encoded byte length $(length(compressed)) does not match output byte size $n"
+    ))
+    GC.@preserve data compressed unsafe_copyto!(Ptr{UInt8}(pointer(data)),
+                                                pointer(compressed), n)
+    return data
+end
+
 JSON.lower(::NoCompressor) = nothing
 
 compressortypes[nothing] = NoCompressor

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -160,6 +160,19 @@ _zero(::Type{<:Vector{T}}) where T = T[]
 _zero(::Type{Char}) = Char(0)
 getchunkarray(z::ZArray) = fill(_zero(eltype(z)), z.metadata.chunks)
 
+# Same as `getchunkarray` but skips the zero/fill_value-fill. Use only when
+# the caller guarantees the buffer will be fully overwritten before any read
+# (e.g. decode-into or full-chunk-write paths).
+#
+# Falls back to the standard `getchunkarray` for `>:Missing` element types:
+# the codec pipeline requires the underlying buffer to be the `isbits` inner
+# of a `SenMissArray`, not an `Array{Union{Missing,T}}` directly (Blosc and
+# friends reject non-isbits eltypes).
+function getchunkarray_undef(z::ZArray{T}) where {T}
+    Missing <: T && return getchunkarray(z)
+    return Array{T}(undef, z.metadata.chunks)
+end
+
 maybeinner(a::Array) = a
 maybeinner(a::SenMissArray) = a.x
 resetbuffer!(fv,a::Array) = fv === nothing || fill!(a,fv)
@@ -172,9 +185,11 @@ function readblock!(aout::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::Cartes
   output_base_offsets = map(i->first(i)-1,r.indices)
   # Determines which chunks are affected
   blockr = CartesianIndices(map(trans_ind, r.indices, z.metadata.chunks))
-  # Allocate array of the size of a chunks where uncompressed data can be held
-  #bufferdict = IdDict((current_task()=>getchunkarray(z),))
-  a = getchunkarray(z)
+  # Allocate the chunk-shaped scratch buffer. Reads always either fill it
+  # from a decode (which writes every element) or fall through to the
+  # fill-value path (which calls `fill!` itself), so we don't need to
+  # pre-zero it.
+  a = getchunkarray_undef(z)
   # Now loop through the chunks
   c = Channel{Pair{eltype(blockr),Union{Nothing,Vector{UInt8}}}}(channelsize(z.storage))
   
@@ -208,9 +223,11 @@ function writeblock!(ain::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::Cartes
   input_base_offsets = map(i->first(i)-1,r.indices)
   # Determines which chunks are affected
   blockr = CartesianIndices(map(trans_ind, r.indices, z.metadata.chunks))
-  # Allocate array of the size of a chunks where uncompressed data can be held
-  #bufferdict = IdDict((current_task()=>getchunkarray(z),))
-  a = getchunkarray(z)
+  # If `fill_value === nothing`, the legacy behaviour is that un-written
+  # cells in a partial-write to a new chunk default to zero (via the
+  # zero-fill of `getchunkarray`). Preserve that. Otherwise `resetbuffer!`
+  # handles initialisation explicitly and we save the dead memset.
+  a = z.metadata.fill_value === nothing ? getchunkarray(z) : getchunkarray_undef(z)
   # Now loop through the chunks
   readchannel = Channel{Pair{eltype(blockr),Union{Nothing,Vector{UInt8}}}}(channelsize(z.storage))
   

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -181,10 +181,23 @@ resetbuffer!(_,a::SenMissArray) = fill!(a,missing)
 # Function to read or write from a zarr array. Could be refactored
 # using type system to get rid of the `if readmode` statements.
 function readblock!(aout::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::CartesianIndices{N}) where {N}
-  
+
   output_base_offsets = map(i->first(i)-1,r.indices)
   # Determines which chunks are affected
   blockr = CartesianIndices(map(trans_ind, r.indices, z.metadata.chunks))
+  # Fast path: single-chunk full-read decodes directly into `aout`, skipping the readtask channel and scratch buffer.
+  T = eltype(z)
+  if length(blockr) == 1 && aout isa Array && !(Missing <: T) &&
+     eltype(aout) === T && size(aout) == z.metadata.chunks
+    bI = first(blockr)
+    current_chunk_offsets = map((s,i)->s*(i-1), z.metadata.chunks, Tuple(bI))
+    indranges = map(boundint, r.indices, z.metadata.chunks, current_chunk_offsets)
+    if length.(indranges) == z.metadata.chunks
+      chunk_compressed = store_readchunk(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
+      uncompress_raw!(aout, z, chunk_compressed)
+      return aout
+    end
+  end
   # Allocate the chunk-shaped scratch buffer. Reads always either fill it
   # from a decode (which writes every element) or fall through to the
   # fill-value path (which calls `fill!` itself), so we don't need to

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -218,11 +218,30 @@ function readblock!(aout::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::Cartes
 end
 
 function writeblock!(ain::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::CartesianIndices{N}) where {N}
-  
+
   z.writeable || error("Can not write to read-only ZArray")
   input_base_offsets = map(i->first(i)-1,r.indices)
   # Determines which chunks are affected
   blockr = CartesianIndices(map(trans_ind, r.indices, z.metadata.chunks))
+  # Fast path: single-chunk full-overwrite skips the readtask/writetask channels and the scratch buffer.
+  T = eltype(z)
+  if length(blockr) == 1 && ain isa Array && !(Missing <: T) &&
+     eltype(ain) === T && size(ain) == z.metadata.chunks
+    bI = first(blockr)
+    current_chunk_offsets = map((s,i)->s*(i-1), z.metadata.chunks, Tuple(bI))
+    indranges = map(boundint, r.indices, z.metadata.chunks, current_chunk_offsets)
+    if length.(indranges) == z.metadata.chunks
+      data_encoded = compress_raw(ain, z)
+      if isnothing(data_encoded)
+        if store_isinitialized(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
+          store_deletechunk(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
+        end
+      else
+        store_writechunk(z.storage, data_encoded, z.path, bI, z.metadata.chunk_key_encoding)
+      end
+      return ain
+    end
+  end
   # If `fill_value === nothing`, the legacy behaviour is that un-written
   # cells in a partial-write to a new chunk default to zero (via the
   # zero-fill of `getchunkarray`). Preserve that. Otherwise `resetbuffer!`

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -178,6 +178,17 @@ maybeinner(a::SenMissArray) = a.x
 resetbuffer!(fv,a::Array) = fv === nothing || fill!(a,fv)
 resetbuffer!(_,a::SenMissArray) = fill!(a,missing)
 
+# Returns the chunk index when the call qualifies for the single-chunk fast
+# path: a plain `Array{T,N}` matching the chunk shape, `Missing <: T` false,
+# and only one chunk touched. `size(arr) == chunks` with `length(blockr) == 1`
+# implies the slice aligns with that chunk's full range, so no extra
+# coverage check is needed.
+function singlechunk_fastpath(arr, z::ZArray{T,N}, blockr::CartesianIndices{N}) where {T,N}
+  arr isa Array{T,N} && !(Missing <: T) &&
+    size(arr) == z.metadata.chunks && length(blockr) == 1 || return nothing
+  return first(blockr)
+end
+
 # Function to read or write from a zarr array. Could be refactored
 # using type system to get rid of the `if readmode` statements.
 function readblock!(aout::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::CartesianIndices{N}) where {N}
@@ -186,17 +197,11 @@ function readblock!(aout::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::Cartes
   # Determines which chunks are affected
   blockr = CartesianIndices(map(trans_ind, r.indices, z.metadata.chunks))
   # Fast path: single-chunk full-read decodes directly into `aout`, skipping the readtask channel and scratch buffer.
-  T = eltype(z)
-  if length(blockr) == 1 && aout isa Array && !(Missing <: T) &&
-     eltype(aout) === T && size(aout) == z.metadata.chunks
-    bI = first(blockr)
-    current_chunk_offsets = map((s,i)->s*(i-1), z.metadata.chunks, Tuple(bI))
-    indranges = map(boundint, r.indices, z.metadata.chunks, current_chunk_offsets)
-    if length.(indranges) == z.metadata.chunks
-      chunk_compressed = store_readchunk(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
-      uncompress_raw!(aout, z, chunk_compressed)
-      return aout
-    end
+  bI = singlechunk_fastpath(aout, z, blockr)
+  if bI !== nothing
+    chunk_compressed = store_readchunk(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
+    uncompress_raw!(aout, z, chunk_compressed)
+    return aout
   end
   # Allocate the chunk-shaped scratch buffer. Reads always either fill it
   # from a decode (which writes every element) or fall through to the
@@ -237,23 +242,17 @@ function writeblock!(ain::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::Cartes
   # Determines which chunks are affected
   blockr = CartesianIndices(map(trans_ind, r.indices, z.metadata.chunks))
   # Fast path: single-chunk full-overwrite skips the readtask/writetask channels and the scratch buffer.
-  T = eltype(z)
-  if length(blockr) == 1 && ain isa Array && !(Missing <: T) &&
-     eltype(ain) === T && size(ain) == z.metadata.chunks
-    bI = first(blockr)
-    current_chunk_offsets = map((s,i)->s*(i-1), z.metadata.chunks, Tuple(bI))
-    indranges = map(boundint, r.indices, z.metadata.chunks, current_chunk_offsets)
-    if length.(indranges) == z.metadata.chunks
-      data_encoded = compress_raw(ain, z)
-      if isnothing(data_encoded)
-        if store_isinitialized(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
-          store_deletechunk(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
-        end
-      else
-        store_writechunk(z.storage, data_encoded, z.path, bI, z.metadata.chunk_key_encoding)
+  bI = singlechunk_fastpath(ain, z, blockr)
+  if bI !== nothing
+    data_encoded = compress_raw(ain, z)
+    if isnothing(data_encoded)
+      if store_isinitialized(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
+        store_deletechunk(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
       end
-      return ain
+    else
+      store_writechunk(z.storage, data_encoded, z.path, bI, z.metadata.chunk_key_encoding)
     end
+    return ain
   end
   # If `fill_value === nothing`, the legacy behaviour is that un-written
   # cells in a partial-write to a new chunk default to zero (via the

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -189,6 +189,47 @@ function singlechunk_fastpath(arr, z::ZArray{T,N}, blockr::CartesianIndices{N}) 
   return first(blockr)
 end
 
+# Single-chunk full-overwrite write. Encodes `ain` and pushes the chunk to
+# the store. Split out of `writeblock!` so we can specialize on metadata
+# type below.
+function write_singlechunk_fastpath!(z::ZArray, ain::Array, bI::CartesianIndex)
+  data_encoded = compress_raw(ain, z)
+  if data_encoded === nothing
+    if store_isinitialized(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
+      store_deletechunk(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
+    end
+  else
+    store_writechunk(z.storage, data_encoded, z.path, bI, z.metadata.chunk_key_encoding)
+  end
+  return nothing
+end
+
+# Zero-copy write for V2 with no compressor and no filters: the on-disk
+# bytes are exactly `ain`'s in-memory representation (Zarr V2 default
+# little-endian matches Julia on little-endian hosts — i.e. all currently
+# supported platforms), so pass a `reinterpret(UInt8, ain)` view straight
+# to the store and skip the chunk-sized `Vector{UInt8}` allocation +
+# memcpy that the generic pipeline performs.
+#
+# Safe to hand out a view (not an owned copy) because the singlechunk
+# fastpath guarantees `ain` is the caller's input array, not the shared
+# scratch buffer the multi-chunk path reuses across iterations.
+function write_singlechunk_fastpath!(
+  z::ZArray{T,N,<:AbstractStore,<:MetadataV2{T,N,NoCompressor,Nothing}},
+  ain::Array{T,N}, bI::CartesianIndex,
+) where {T,N}
+  fv = z.metadata.fill_value
+  if fv !== nothing && all(isequal(fv), ain)
+    if store_isinitialized(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
+      store_deletechunk(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
+    end
+    return nothing
+  end
+  store_writechunk(z.storage, _reinterpret(UInt8, ain),
+                   z.path, bI, z.metadata.chunk_key_encoding)
+  return nothing
+end
+
 # Function to read or write from a zarr array. Could be refactored
 # using type system to get rid of the `if readmode` statements.
 function readblock!(aout::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::CartesianIndices{N}) where {N}
@@ -244,14 +285,7 @@ function writeblock!(ain::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::Cartes
   # Fast path: single-chunk full-overwrite skips the readtask/writetask channels and the scratch buffer.
   bI = singlechunk_fastpath(ain, z, blockr)
   if bI !== nothing
-    data_encoded = compress_raw(ain, z)
-    if isnothing(data_encoded)
-      if store_isinitialized(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
-        store_deletechunk(z.storage, z.path, bI, z.metadata.chunk_key_encoding)
-      end
-    else
-      store_writechunk(z.storage, data_encoded, z.path, bI, z.metadata.chunk_key_encoding)
-    end
+    write_singlechunk_fastpath!(z, ain, bI)
     return ain
   end
   # If `fill_value === nothing`, the legacy behaviour is that un-written

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,6 +83,93 @@ using Dates
             GC.gc()
         end
     end
+
+    @testset "NoCompressor single-chunk zero-copy fastpath" begin
+        # The V2+NoCompressor+no-filters specialization of
+        # `write_singlechunk_fastpath!` hands a `reinterpret(UInt8, ain)` view
+        # straight to the store instead of allocating a chunk-sized
+        # `Vector{UInt8}` and memcpy'ing into it. The on-disk bytes must
+        # still match the array's bit pattern exactly.
+
+        # Dispatch: the specialized method is selected for V2 + NoCompressor + no filters.
+        mktempdir(@__DIR__) do dir
+            z3 = zcreate(Float32, 4, 4, 2; path=joinpath(dir, "disp"),
+                         chunks=(4, 4, 2), compressor=Zarr.NoCompressor())
+            ain = rand(Float32, 4, 4, 2)
+            m = which(Zarr.write_singlechunk_fastpath!, (typeof(z3), typeof(ain), CartesianIndex{3}))
+            @test occursin("MetadataV2", string(m.sig))
+            @test occursin("NoCompressor", string(m.sig))
+            GC.gc()
+        end
+
+        # Round-trip across rank 0, 1, 3, 4 and a mix of bitstypes.
+        mktempdir(@__DIR__) do dir
+            for (T, shape) in ((Float32, (8, 8, 4)),
+                               (Int64,   (5, 3)),
+                               (UInt16,  (16,)),
+                               (ComplexF32, (4, 4)),
+                               (Float64, ()))
+                name = "rt_$(T)_$(length(shape))d"
+                # Match chunks to full shape so writes hit the single-chunk fastpath.
+                chunks = shape == () ? () : shape
+                z = zcreate(T, shape...; path=joinpath(dir, name),
+                            chunks=chunks, compressor=Zarr.NoCompressor())
+                # Drive `ain` through a controlled byte pattern so round-trip
+                # failure can't be masked by zero-init.
+                ain = T === ComplexF32 ?
+                    reshape(ComplexF32[ComplexF32(i, -i) for i in 1:prod(shape == () ? (1,) : shape)],
+                            shape == () ? () : shape) :
+                    reshape(T[T(i) for i in 1:prod(shape == () ? (1,) : shape)],
+                            shape == () ? () : shape)
+                if shape == ()
+                    z[] = ain[]
+                else
+                    z[(Colon() for _ in shape)...] = ain
+                end
+                # On-disk chunk file equals reinterpret(UInt8, ain).
+                chunk_path = shape == () ? joinpath(dir, name, "0") :
+                             joinpath(dir, name, join(fill("0", length(shape)), "."))
+                @test isfile(chunk_path)
+                on_disk = read(chunk_path)
+                expected = Vector{UInt8}(undef, sizeof(ain))
+                GC.@preserve ain expected unsafe_copyto!(pointer(expected),
+                    Ptr{UInt8}(pointer(ain)), sizeof(ain))
+                @test on_disk == expected
+                # Reads round-trip via the regular Zarr.jl path.
+                @test Array(zopen(joinpath(dir, name))) == ain
+                GC.gc()
+            end
+        end
+
+        # All-fill-value chunks are elided (no on-disk file written) — same
+        # semantics as the generic V2 pipeline_encode.
+        mktempdir(@__DIR__) do dir
+            z = zcreate(Float32, 4, 4; path=joinpath(dir, "elide"),
+                        chunks=(4, 4), compressor=Zarr.NoCompressor(),
+                        fill_value=Float32(7))
+            z[:, :] = fill(Float32(7), 4, 4)
+            @test !ispath(joinpath(dir, "elide", "0.0"))
+            # Overwriting an existing chunk with all-fill removes the file.
+            z[:, :] = rand(Float32, 4, 4)
+            @test ispath(joinpath(dir, "elide", "0.0"))
+            z[:, :] = fill(Float32(7), 4, 4)
+            @test !ispath(joinpath(dir, "elide", "0.0"))
+            GC.gc()
+        end
+
+        # The store must fully consume the reinterpret view before returning:
+        # mutating `ain` after the write must not affect on-disk content.
+        mktempdir(@__DIR__) do dir
+            z = zcreate(Float32, 8, 8; path=joinpath(dir, "alias"),
+                        chunks=(8, 8), compressor=Zarr.NoCompressor())
+            ain = rand(Float32, 8, 8)
+            snapshot = copy(ain)
+            z[:, :] = ain
+            fill!(ain, Float32(NaN))                  # clobber after the write returns
+            @test zopen(joinpath(dir, "alias"))[:, :] == snapshot
+            GC.gc()
+        end
+    end
 end
 
 @testset "Groups" begin


### PR DESCRIPTION
This PR works through @glwagner's list of V2 performance issues and lands the biggest wins as separate commits. V3 is out of scope here (covered separately).

## Commits

| | sha | summary |
|---|---|---|
| 1 | `59644e4` | A1 — bulk-copy `zcompress!` fallback |
| 2 | `50fbc16` | B1 — bulk-copy `NoCompressor` `zuncompress!` |
| 3 | `c046338` | A2 — `getchunkarray_undef` skips dead zero-fill |
| 4 | `ebc3ea1` | A3-write — `writeblock!` single-chunk fast path |
| 5 | `d846986` | A3-read — `readblock!` single-chunk fast path |
| 6 | `3839b95` | factor `singlechunk_fastpath` guard helper |

### A1 — `zcompress!` fallback (`59644e4`)

Replace `empty!` + `append!` with `resize!` + `copyto!` in the generic `zcompress!` fallback in `Compressors.jl`. For `NoCompressor`, `zcompress` returns a lazy `reinterpret(UInt8, data)` view that the old path walked element-by-element through `_growend!` / `push!` — about 67% of CPU on uncompressed V2 write profiles. The new path is a single SIMD/memcpy bulk copy. Real compressors (Blosc/Zstd/Zlib) already return a `Vector{UInt8}` and `copyto!` handles them identically.

### B1 — `NoCompressor` `zuncompress!` (`50fbc16`)

Mirror image for the decode side. The generic fallback ends up at `copyto!(::Array{T}, ::ReinterpretArray)`, which walks element-by-element at ~17 GB/s on Apple silicon vs. ~85 GB/s for `unsafe_copyto!` on the same memory. Add a `::NoCompressor`-dispatched `zuncompress!` method alongside the existing per-compressor versions (Zstd / Zlib / Blosc already had their own). Guards on `data::Array{T}` and `isbitstype(T)` keep the fast path off `SenMissArray`, `MaxLengthString`, ragged `Vector{T}` eltypes, and non-contiguous inputs.

### A2 — `getchunkarray_undef` (`c046338`)

Both `readblock!` and `writeblock!` allocated their chunk-shaped scratch buffer via `getchunkarray(z) = fill(_zero(eltype(z)), z.metadata.chunks)`, then immediately overwrote it (decode writes every element on reads; `resetbuffer!` re-initialises on writes). Add `getchunkarray_undef(z::ZArray{T})` returning `Array{T}(undef, chunks)`, used by `readblock!` always and by `writeblock!` when `fill_value !== nothing`. Falls back to the zero-fill when `Missing <: T` (the `SenMissArray` codec path needs the isbits inner buffer; Blosc rejects `Union{Missing,T}` directly). Port of the V2-side hunks from #272 verbatim, including the `Missing <: T` carve-out that PR added in `75bea38` to fix a Blosc rejection regression.

### A3-write — `writeblock!` fast path (`ebc3ea1`)

PProf of A1+B1+A2 showed 93% of write CPU pinned in `__psynch_cvwait` — the readtask/writetask 0-buffered channel ferry sync wait. For the dominant single-chunk full-overwrite case (`z[:,:,:,t] = buf`), add a fast path that bypasses the channels entirely: encode `ain` straight through `compress_raw` and call `store_writechunk` / `store_deletechunk` synchronously. Fill-value elision is preserved. Anything else falls through to the channel-based path. Skips `Missing <: T` so the `SenMissArray` codec contract stays intact.

### A3-read — `readblock!` fast path (`d846986`)

Same idea on the read side. Profile showed 80% read CPU in `__psynch_cvwait` plus 13% GC pressure from the per-call chunk-shaped scratch + final copy. The fast path reads the compressed bytes synchronously via `store_readchunk` and decodes directly into `aout`, eliminating both the channel ferry and the scratch buffer.

### Cleanup — `singlechunk_fastpath` helper (`3839b95`)

Both fast paths share the same eligibility check. Factor it into `singlechunk_fastpath(arr, z, blockr) -> Union{CartesianIndex, Nothing}` so each caller's fast-path body is just the I/O. Also drops the redundant `indranges` coverage check — when `size(arr) == chunks` and `length(blockr) == 1`, the slice must align with that chunk's range (otherwise it would straddle into a neighbouring chunk and bump `length(blockr)`).

## Combined effect — master vs HEAD

Apple M2 Ultra, Julia 1.12.6, V2 + NoCompressor + `chunks=(Nx,Ny,Nz,1)`, 1 warm-up + 7 timed repeats per size, matched A/B (`git checkout 03270b2 -- src/` then back) on the same wall-clock so cache state and power profile are identical:

### Writes

| size | master (03270b2) | this PR | speed-up |
|---|---:|---:|---:|
| 128×128×16×50 (50 MiB)   |  710 MB/s | 2172 MB/s | **3.06×** |
| 256×256×32×50 (400 MiB)  |  740 MB/s | 2313 MB/s | **3.12×** |
| 512×512×32×50 (1.56 GiB) |  757 MB/s | 2184 MB/s | **2.88×** |

### Reads

| size | master (03270b2) | this PR | speed-up |
|---|---:|---:|---:|
| 128×128×16×50 (50 MiB)   | 3261 MB/s | 7061 MB/s | **2.16×** |
| 256×256×32×50 (400 MiB)  | 3008 MB/s | 6746 MB/s | **2.24×** |
| 512×512×32×50 (1.56 GiB) | 3304 MB/s | 8010 MB/s | **2.42×** |

### vs Zarrs.jl

For reference, Zarrs.jl (the Rust-backed implementation) on the same workload:

| size | this PR (W) | Zarrs (W) | this PR (R) | Zarrs (R) |
|---|---:|---:|---:|---:|
| 50 MiB  | 2172 | 1109 | 7061 | 5435 |
| 400 MiB | 2313 | 1889 | 6746 | 5053 |
| 1.5 GiB | 2184 | 1991 | 8010 | 3697 |

Zarr.jl is now **faster than Zarrs.jl** on uncompressed V2 across all three sizes, on both writes (1.10–1.96×) and reads (1.30–2.17×).

## Tests

2499/2499 pass after each commit. Paths exercised:

- `SenMissArray` / `Missing <: T` — `Fillvalue as missing` and the `getindex/setindex` amiss tests
- `MaxLengthString large-chunk read path`
- Ragged arrays (`Vector{Float64}` eltype)
- Python round-trip via PythonCall
- V3 fill-value elision (`v3_codecs.jl:336`) — V3 path is unchanged

## Not in this PR

- **V3 path.** `BytesCodec` encode/decode bulk-copy and the exact-full-chunk overwrite path are still open; covered by upstream #272 (V3 portion) and a separate write-up.
- **A5** — thread a scratch `Vector{UInt8}` through `pipeline_encode` (main benefit is for compressed codecs, not NoCompressor).
- **A6** — `DirectoryStore` `mkdir` cache (bigger win for many-small-chunks workloads).
- **Dropping `all(isequal(fill_value), data)`.** Confirmed no measurable win on dense bench data (`all` short-circuits at element 1 in nanoseconds) and has real semantic cost: it implements Zarr's fill-value chunk elision, which would change the on-disk shape for sparse arrays and re-writes-with-fill, plus break 3 tests.
