### PR TITLE
fix: write chunks in the ConcurrentRead write_items! path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix the `ConcurrentRead` write path silently dropping chunk writes; affected stores such as `S3Store` wrote array metadata but no data chunks [#297](https://github.com/JuliaIO/Zarr.jl/pull/297)
 - Added reading compat for stores produced in python with `numcodecs.blosc` [#286](https://github.com/JuliaIO/Zarr.jl/pull/286)
 - Bump HTTP compat to 2 [#284](https://github.com/JuliaIO/Zarr.jl/pull/284)
 - V2 performance improvements [#280](https://github.com/JuliaIO/Zarr.jl/pull/280)

--- a/src/Storage/Storage.jl
+++ b/src/Storage/Storage.jl
@@ -278,7 +278,7 @@ function write_items!(s::AbstractStore, c::AbstractChannel, r::ConcurrentRead, e
         store_deletechunk(s, p, ii, e)
         end
       else
-      store_writechunk(s, data, p, ii, e) = data
+      store_writechunk(s, data, p, ii, e)
       end
       nothing
   end

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -402,3 +402,27 @@ end
   # Cleanup
   rm(cache_dir, recursive=true)
 end
+
+# A store identical to DictStore but advertising the ConcurrentRead strategy
+# (as S3Store does), to exercise the concurrent write path.
+struct ConcurrentDictStore <: Zarr.AbstractStore
+  inner::Zarr.DictStore
+end
+ConcurrentDictStore() = ConcurrentDictStore(Zarr.DictStore())
+Base.getindex(s::ConcurrentDictStore, i::AbstractString) = s.inner[i]
+Base.setindex!(s::ConcurrentDictStore, v, i::AbstractString) = (s.inner[i] = v)
+Base.delete!(s::ConcurrentDictStore, i::AbstractString) = delete!(s.inner, i)
+Zarr.subdirs(s::ConcurrentDictStore, p) = Zarr.subdirs(s.inner, p)
+Zarr.subkeys(s::ConcurrentDictStore, p) = Zarr.subkeys(s.inner, p)
+Zarr.storagesize(s::ConcurrentDictStore, p) = Zarr.storagesize(s.inner, p)
+Zarr.store_read_strategy(::ConcurrentDictStore) = Zarr.ConcurrentRead(4)
+
+@testset "ConcurrentRead stores persist chunk writes" begin
+  data = reshape(collect(Float32, 1:12), 3, 4)
+  store = ConcurrentDictStore()
+  g = zgroup(store)
+  a = zcreate(Float32, g, "x", 3, 4; chunks=(3, 4))
+  a[:, :] = data
+  @test haskey(store.inner.a, "x/0.0")   # chunk data actually written, not just metadata
+  @test a[:, :] == data                  # round-trips through the store
+end


### PR DESCRIPTION
## Problem

`write_items!` for the `ConcurrentRead` strategy silently drops every chunk write. Stores that advertise `ConcurrentRead` — notably `S3Store` — end up with array metadata (`.zarray`/`.zattrs`) written but **no data chunks**, and no error is raised.

The cause is a one-character typo in `src/Storage/Storage.jl`. The `ConcurrentRead` method writes a chunk with:

```julia
store_writechunk(s, data, p, ii, e) = data
```

The `= data` makes this a **no-op local function definition** (short-form `f(args) = body`) instead of a call, so `store_writechunk` is never invoked and the chunk is never written. The `SequentialRead` method just above it calls it correctly:

```julia
store_writechunk(s, data, p, ii, e)
```

This is why `DirectoryStore`/`DictStore` (default `SequentialRead`) write correctly while `S3Store` (`ConcurrentRead`) produces metadata-only stores.

## Fix

Drop the `= data` so the chunk is actually written.

## Reproduction (no S3 needed)

A `DictStore` wrapper whose only difference is advertising `ConcurrentRead`:

```julia
using Zarr
import Zarr: AbstractStore, DictStore, ConcurrentRead, store_read_strategy, subdirs, subkeys

struct ConcurrentDictStore <: AbstractStore
    inner::DictStore
end
ConcurrentDictStore() = ConcurrentDictStore(DictStore())
Base.getindex(s::ConcurrentDictStore, i::AbstractString) = s.inner[i]
Base.setindex!(s::ConcurrentDictStore, v, i::AbstractString) = (s.inner[i] = v)
Base.delete!(s::ConcurrentDictStore, i::AbstractString) = delete!(s.inner, i)
subdirs(s::ConcurrentDictStore, p) = subdirs(s.inner, p)
subkeys(s::ConcurrentDictStore, p) = subkeys(s.inner, p)
Zarr.storagesize(s::ConcurrentDictStore, p) = Zarr.storagesize(s.inner, p)
store_read_strategy(::ConcurrentDictStore) = ConcurrentRead(4)

data = reshape(collect(Float32, 1:12), 3, 4)
store = ConcurrentDictStore()
a = zcreate(Float32, zgroup(store), "x", 3, 4; chunks=(3, 4))
a[:, :] = data

@assert haskey(store.inner.a, "x/0.0")  # fails on current main — chunk never written
```

On `main` the chunk key is absent; with this fix it is present and round-trips.

## Test

Adds a regression test in `test/storage.jl` using the wrapper above, asserting the chunk is written and round-trips.

## Note

This looks related to #275 / #281 (the `wait(writetask)` fix): that addressed write-task *timing*, but the chunk write in the `ConcurrentRead` path is a no-op, so waiting for it still writes nothing. The no-op is still present on `master`.

Regressed in #226 (the v3 rewrite, shipped in 0.10.0): the direct `s[p,ii] = data` write was refactored into a `store_writechunk` helper, and the `ConcurrentRead` branch's call was written as an assignment. `v0.9.6` wrote chunks correctly.
