### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
     tags: '*'
 jobs:
   test:

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -1,7 +1,7 @@
 name: Documenter
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: [v*]
   pull_request:
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,9 +3,9 @@ name: Codespell
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ z2[1:10,1:10]
 [docs-dev-img]: https://img.shields.io/badge/documentation-in%20development-orange?style=round-square
 [docs-dev-url]: https://juliaio.github.io/Zarr.jl/dev/
 
-[codecov-img]: https://codecov.io/gh/JuliaIO/Zarr.jl/branch/master/graph/badge.svg
+[codecov-img]: https://codecov.io/gh/JuliaIO/Zarr.jl/branch/main/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/JuliaIO/Zarr.jl
 
 [ci-img]: https://github.com/JuliaIO/Zarr.jl/actions/workflows/CI.yml/badge.svg?style=round-square

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,7 +10,7 @@ makedocs(
     doctest = true,
     format = DocumenterVitepress.MarkdownVitepress(
         repo = "github.com/JuliaIO/Zarr.jl",
-        devbranch = "master",
+        devbranch = "main",
         devurl = "dev",
     ),
     source = "src",
@@ -27,6 +27,6 @@ DocumenterVitepress.deploydocs(
     repo = "github.com/JuliaIO/Zarr.jl.git",
     target = joinpath(@__DIR__, "build"),
     branch = "gh-pages",
-    devbranch = "master",
+    devbranch = "main",
     push_preview = true,
 )


### PR DESCRIPTION
This replaces master with main in settings and links. 

@mkitti could you please make the switch in the github settings. 

I am not sure whether there are other external tools where we would have to change it in some settings. 

There is codecov where we would have to change the default branch to main.

This is on the way to closing #233 