### PR TITLE
v3: implement vlen-utf8 codec for reading and writing strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Add logo and favicon to docs [#307](https://github.com/JuliaIO/Zarr.jl/pull/307)
+- Support reading and writing variable-length strings [#311](https://github.com/JuliaIO/Zarr.jl/pull/311)
 
 ## v0.10.1 - 2026-07-07
 

--- a/src/Codecs/V3/V3.jl
+++ b/src/Codecs/V3/V3.jl
@@ -784,6 +784,11 @@ function codec_decode(c::CRC32cV3Codec, encoded::Vector{UInt8})
     return zdecode!(out, encoded, CRC32cCodec())
 end
 
+"""
+    VLenUTF8V3Codec
+
+Variable-length UTF-8 string codec for Zarr v3. See https://github.com/zarr-developers/zarr-extensions/tree/main/codecs/vlen-utf8.
+"""
 struct VLenUTF8V3Codec <: V3Codec{:array, :bytes} end
 name(::VLenUTF8V3Codec) = "vlen-utf8"
 register_codec("vlen-utf8", VLenUTF8V3Codec) do config, ctx

--- a/src/Codecs/V3/V3.jl
+++ b/src/Codecs/V3/V3.jl
@@ -803,11 +803,12 @@ function codec_encode(::VLenUTF8V3Codec, data::AbstractArray{<:AbstractString})
     end
     take!(b)
 end
-function codec_decode(::VLenUTF8V3Codec, encoded::Vector{UInt8}, ::Type{T}, shape::NTuple{N,Int}; fill_value::T=zero(T)) where {T <: AbstractString, N}
+function codec_decode(::VLenUTF8V3Codec, encoded::Vector{UInt8}, ::Type{T}, shape::NTuple{N,Int}; fill_value::T= Missing <: T ? missing : zero(T)) where {T <: Union{<:AbstractString, Missing}, N}
     f = IOBuffer(encoded, read=true, write=false)
     nitems = ltoh(read(f, UInt32))
-    if nitems != prod(shape)
-        throw(DimensionMismatch("Got shape $shape ($(prod(shape)) items), but the array only has $nitems items."))
+    expected = prod(shape)
+    if nitems != expected
+        throw(DimensionMismatch("Got shape $shape ($expected items), but the array only has $nitems items."))
     end
     out = Array{T}(undef, shape...)
     for i in 1:nitems

--- a/src/Codecs/V3/V3.jl
+++ b/src/Codecs/V3/V3.jl
@@ -784,4 +784,37 @@ function codec_decode(c::CRC32cV3Codec, encoded::Vector{UInt8})
     return zdecode!(out, encoded, CRC32cCodec())
 end
 
+struct VLenUTF8V3Codec <: V3Codec{:array, :bytes} end
+name(::VLenUTF8V3Codec) = "vlen-utf8"
+register_codec("vlen-utf8", VLenUTF8V3Codec) do config, ctx
+    VLenUTF8V3Codec()
+end
+function JSON.lower(::VLenUTF8V3Codec)
+    Dict("name" => "vlen-utf8")
+end
+function codec_encode(::VLenUTF8V3Codec, data::AbstractArray{<:AbstractString})
+    b = IOBuffer()
+    nitems = length(data)
+    write(b, htol(UInt32(nitems)))
+    for a in data
+        utf8encoded = transcode(String, a)
+        write(b, htol(UInt32(ncodeunits(utf8encoded))))
+        write(b, utf8encoded)
+    end
+    take!(b)
+end
+function codec_decode(::VLenUTF8V3Codec, encoded::Vector{UInt8}, ::Type{T}, shape::NTuple{N,Int}; fill_value::T=zero(T)) where {T <: AbstractString, N}
+    f = IOBuffer(encoded, read=true, write=false)
+    nitems = ltoh(read(f, UInt32))
+    if nitems != prod(shape)
+        throw(DimensionMismatch("Got shape $shape ($(prod(shape)) items), but the array only has $nitems items."))
+    end
+    out = Array{T}(undef, shape...)
+    for i in 1:nitems
+        clen = ltoh(read(f, UInt32))
+        out[i] = String(read(f, clen))
+    end
+    out
+end
+
 end

--- a/src/metadata3.jl
+++ b/src/metadata3.jl
@@ -101,11 +101,17 @@ function MetadataV3{T2,N}(zarr_format, node_type, shape::NTuple{N,Int}, chunks::
     else
         ()
     end
-    array_bytes_codec = Codecs.V3Codecs.BytesCodec(endian)
+    if T_base <: AbstractString
+        array_bytes_codec = Codecs.V3Codecs.VLenUTF8V3Codec()
+        typesize = 4
+    else
+        array_bytes_codec = Codecs.V3Codecs.BytesCodec(endian)
+        typesize = sizeof(T_base)
+    end
     bytes_bytes_codecs = if compressor isa NoCompressor
         ()
     elseif compressor isa BloscCompressor
-        (Codecs.V3Codecs.BloscV3Codec(compressor.cname, compressor.clevel, compressor.shuffle, compressor.blocksize, sizeof(T_base)),)
+        (Codecs.V3Codecs.BloscV3Codec(compressor.cname, compressor.clevel, compressor.shuffle, compressor.blocksize, typesize),)
     elseif compressor isa ZlibCompressor
         # ZlibCompressor uses -1 to mean "default"; zarr v3 gzip spec requires 0-9
         level = compressor.config.level == -1 ? 6 : compressor.config.level

--- a/src/metadata3.jl
+++ b/src/metadata3.jl
@@ -101,7 +101,7 @@ function MetadataV3{T2,N}(zarr_format, node_type, shape::NTuple{N,Int}, chunks::
     else
         ()
     end
-    if T_base <: AbstractString
+    if T_base <: AbstractString && T_base !== MaxLengthString
         array_bytes_codec = Codecs.V3Codecs.VLenUTF8V3Codec()
         typesize = 4
     else

--- a/test/v3_codecs.jl
+++ b/test/v3_codecs.jl
@@ -797,9 +797,9 @@ end
             @test pyconvert(Vector{Int16},   np.array(g["1d.contiguous.gzip.i2"]))  == Int16[1, 2, 3, 4]
             @test pyconvert(Vector{Int16},   np.array(g["1d.contiguous.blosc.i2"])) == Int16[1, 2, 3, 4]
             @test pyconvert(Vector{Int16},   np.array(g["1d.contiguous.raw.i2"]))   == Int16[1, 2, 3, 4]
-            @test pyconvert(Vector{String},   np.array(g["1d.contiguous.gzip.string"]))   == String["1", "2", "3", "4"]
-            @test pyconvert(Vector{String},   np.array(g["1d.contiguous.blosc.string"]))   == String["1", "2", "3", "4"]
-            @test pyconvert(Vector{String},   np.array(g["1d.contiguous.raw.string"]))   == String["1", "2", "3", "4"]
+            @test pyconvert(Vector{String},   np.array(g["1d.contiguous.gzip.string"]))   == String["variable", "length", "utf8", "string"]
+            @test pyconvert(Vector{String},   np.array(g["1d.contiguous.blosc.string"]))   == String["variable", "length", "utf8", "string"]
+            @test pyconvert(Vector{String},   np.array(g["1d.contiguous.raw.string"]))   == String["variable", "length", "utf8", "string"]
             @test pyconvert(Vector{Int32},   np.array(g["1d.contiguous.i4"]))       == Int32[1, 2, 3, 4]
             @test pyconvert(Vector{UInt8},   np.array(g["1d.contiguous.u1"]))       == UInt8[255, 0, 255, 0]
             @test pyconvert(Vector{Float16}, np.array(g["1d.contiguous.f2.le"]))    == Float16[-1000.5, 0.0, 1000.5, 0.0]
@@ -922,7 +922,7 @@ end
                 z = zopen(store; path="1d.contiguous.$compressor.string")
                 @test eltype(z) == String
                 @test size(z) == (4,)
-                @test z[:] == String["1", "2", "3", "4"]
+                @test z[:] == String["variable", "length", "utf8", "string"]
             end
 
             # Int32

--- a/test/v3_codecs.jl
+++ b/test/v3_codecs.jl
@@ -103,6 +103,15 @@ end
     @test_throws ArgumentError Zarr.get_order(md)
 end
 
+@testset "VLenUTF8V3Codec" begin
+    codec = Zarr.Codecs.V3Codecs.VLenUTF8V3Codec()
+    data = String["1", "23", "4"]
+    encoded = Zarr.Codecs.V3Codecs.codec_encode(codec, data)
+    @test encoded isa Vector{UInt8}
+    decoded = Zarr.Codecs.V3Codecs.codec_decode(codec, encoded, String, (3,))
+    @test decoded == data
+end
+
 @testset "GzipV3Codec" begin
     codec = Zarr.Codecs.V3Codecs.GzipV3Codec(6)
     data = reinterpret(UInt8, Int32[1, 2, 3, 4]) |> collect
@@ -788,6 +797,9 @@ end
             @test pyconvert(Vector{Int16},   np.array(g["1d.contiguous.gzip.i2"]))  == Int16[1, 2, 3, 4]
             @test pyconvert(Vector{Int16},   np.array(g["1d.contiguous.blosc.i2"])) == Int16[1, 2, 3, 4]
             @test pyconvert(Vector{Int16},   np.array(g["1d.contiguous.raw.i2"]))   == Int16[1, 2, 3, 4]
+            @test pyconvert(Vector{String},   np.array(g["1d.contiguous.gzip.string"]))   == String["1", "2", "3", "4"]
+            @test pyconvert(Vector{String},   np.array(g["1d.contiguous.blosc.string"]))   == String["1", "2", "3", "4"]
+            @test pyconvert(Vector{String},   np.array(g["1d.contiguous.raw.string"]))   == String["1", "2", "3", "4"]
             @test pyconvert(Vector{Int32},   np.array(g["1d.contiguous.i4"]))       == Int32[1, 2, 3, 4]
             @test pyconvert(Vector{UInt8},   np.array(g["1d.contiguous.u1"]))       == UInt8[255, 0, 255, 0]
             @test pyconvert(Vector{Float16}, np.array(g["1d.contiguous.f2.le"]))    == Float16[-1000.5, 0.0, 1000.5, 0.0]
@@ -904,6 +916,14 @@ end
             # "raw" — actually zstd in modern Python zarr v3
             z = zopen(store; path="1d.contiguous.raw.i2")
             @test z[:] == Int16[1, 2, 3, 4]
+
+            # String
+            for compressor in ("gzip", "blosc", "raw")
+                z = zopen(store; path="1d.contiguous.$compressor.string")
+                @test eltype(z) == String
+                @test size(z) == (4,)
+                @test z[:] == String["1", "2", "3", "4"]
+            end
 
             # Int32
             z = zopen(store; path="1d.contiguous.i4")

--- a/test/v3_julia.jl
+++ b/test/v3_julia.jl
@@ -60,6 +60,27 @@ create_and_fill(store, "1d.contiguous.raw.i2", Int16[1,2,3,4];
     compressor=Zarr.NoCompressor(),
 )
 
+# 1d.contiguous.gzip.string
+create_and_fill(store, "1d.contiguous.gzip.string", String["1", "2", "3", "4"];
+    shape=(4,),
+    chunks=(4,),
+    compressor=Zarr.ZlibCompressor(),
+)
+
+# 1d.contiguous.blosc.string
+create_and_fill(store, "1d.contiguous.blosc.string", String["1", "2", "3", "4"];
+    shape=(4,),
+    chunks=(4,),
+    compressor=Zarr.BloscCompressor(shuffle=0),  # noshuffle
+)
+
+# 1d.contiguous.raw.string
+create_and_fill(store, "1d.contiguous.raw.string", String["1", "2", "3", "4"];
+    shape=(4,),
+    chunks=(4,),
+    compressor=Zarr.NoCompressor(),
+)
+
 # 1d.contiguous.i4
 create_and_fill(store, "1d.contiguous.i4", Int32[1,2,3,4];
     shape=(4,),

--- a/test/v3_julia.jl
+++ b/test/v3_julia.jl
@@ -61,21 +61,21 @@ create_and_fill(store, "1d.contiguous.raw.i2", Int16[1,2,3,4];
 )
 
 # 1d.contiguous.gzip.string
-create_and_fill(store, "1d.contiguous.gzip.string", String["1", "2", "3", "4"];
+create_and_fill(store, "1d.contiguous.gzip.string", String["variable", "length", "utf8", "string"];
     shape=(4,),
     chunks=(4,),
     compressor=Zarr.ZlibCompressor(),
 )
 
 # 1d.contiguous.blosc.string
-create_and_fill(store, "1d.contiguous.blosc.string", String["1", "2", "3", "4"];
+create_and_fill(store, "1d.contiguous.blosc.string", String["variable", "length", "utf8", "string"];
     shape=(4,),
     chunks=(4,),
     compressor=Zarr.BloscCompressor(shuffle=0),  # noshuffle
 )
 
 # 1d.contiguous.raw.string
-create_and_fill(store, "1d.contiguous.raw.string", String["1", "2", "3", "4"];
+create_and_fill(store, "1d.contiguous.raw.string", String["variable", "length", "utf8", "string"];
     shape=(4,),
     chunks=(4,),
     compressor=Zarr.NoCompressor(),

--- a/test/v3_python.jl
+++ b/test/v3_python.jl
@@ -111,6 +111,36 @@ create_and_fill(store;
     data=[1,2,3,4],
 )
 
+# 1d.contiguous.gzip.string
+create_and_fill(store;
+    name="1d.contiguous.gzip.string",
+    dtype="string",
+    shape=(4,),
+    chunks=(4,),
+    compressors=[codecs.GzipCodec()],
+    data=["1", "2", "3", "4"],
+)
+
+# 1d.contiguous.blosc.string
+create_and_fill(store;
+    name="1d.contiguous.blosc.string",
+    dtype="string",
+    shape=(4,),
+    chunks=(4,),
+    compressors=[codecs.BloscCodec(typesize=4, shuffle="noshuffle")],
+    data=["1", "2", "3", "4"],
+)
+
+# 1d.contiguous.raw.string
+create_and_fill(store;
+    name="1d.contiguous.raw.string",
+    dtype="string",
+    shape=(4,),
+    chunks=(4,),
+    compressors=nothing,
+    data=["1", "2", "3", "4"],
+)
+
 # 1d.contiguous.i4
 create_and_fill(store;
     name="1d.contiguous.i4",

--- a/test/v3_python.jl
+++ b/test/v3_python.jl
@@ -118,7 +118,7 @@ create_and_fill(store;
     shape=(4,),
     chunks=(4,),
     compressors=[codecs.GzipCodec()],
-    data=["1", "2", "3", "4"],
+    data=["variable", "length", "utf8", "string"],
 )
 
 # 1d.contiguous.blosc.string
@@ -128,7 +128,7 @@ create_and_fill(store;
     shape=(4,),
     chunks=(4,),
     compressors=[codecs.BloscCodec(typesize=4, shuffle="noshuffle")],
-    data=["1", "2", "3", "4"],
+    data=["variable", "length", "utf8", "string"],
 )
 
 # 1d.contiguous.raw.string
@@ -138,7 +138,7 @@ create_and_fill(store;
     shape=(4,),
     chunks=(4,),
     compressors=nothing,
-    data=["1", "2", "3", "4"],
+    data=["variable", "length", "utf8", "string"],
 )
 
 # 1d.contiguous.i4


### PR DESCRIPTION
Closes #311. The implementation is largely copied over from `Filters/vlenfilters.jl`.