### PR TITLE
Fix fill_as_missing for zarr v3 arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Make `missing_chunk_return_code!` and `gcs_credentials` public. Stop exposing
   `DateTime64`, `PermanentZarrCache`, `BloscCodec`, and `GzipCodec` through `Zarr`.
 - Declare an explicit public API [#317](https://github.com/JuliaIO/Zarr.jl/pull/317). Every store, codec, filter and compressor type, and every documented extension point, is now `public`; the set of exported names is unchanged. Internals (`Metadata`, `ZarrFormat`, `is_zarray`, `is_zgroup`, `normalize_path`, `MaxLengthString`, ...) are no longer reachable as `Zarr.x` and must be accessed via `Zarr.ZarrCore.x`
+- Fixed `fill_as_missing=true` on zarr v3 arrays, which threw `cannot reinterpret UInt8 as Union{Missing,Float64}` when decoding an initialized chunk.
 
 ## v0.10.2 - 2026-08-19
 

--- a/lib/ZarrCore/src/pipeline.jl
+++ b/lib/ZarrCore/src/pipeline.jl
@@ -42,7 +42,6 @@ function pipeline_decode!(p::V3Pipeline, output::AbstractArray, compressed::Vect
         (sz, codec) -> Codecs.V3Codecs.encoded_shape(codec, sz),
         p.array_array; init=size(output)
     )
-    # `fill_as_missing` output has eltype `Union{T,Missing}` but the stored elements are plain `T`
     arr = Codecs.V3Codecs.codec_decode(p.array_bytes, bytes, Base.nonmissingtype(eltype(output)), intermediate_shape; fill_value)
     # Phase 1 reverse: array->array codecs (reverse order)
     for codec in reverse(collect(p.array_array))

--- a/lib/ZarrCore/src/pipeline.jl
+++ b/lib/ZarrCore/src/pipeline.jl
@@ -42,7 +42,8 @@ function pipeline_decode!(p::V3Pipeline, output::AbstractArray, compressed::Vect
         (sz, codec) -> Codecs.V3Codecs.encoded_shape(codec, sz),
         p.array_array; init=size(output)
     )
-    arr = Codecs.V3Codecs.codec_decode(p.array_bytes, bytes, eltype(output), intermediate_shape; fill_value)
+    # `fill_as_missing` output has eltype `Union{T,Missing}` but the stored elements are plain `T`
+    arr = Codecs.V3Codecs.codec_decode(p.array_bytes, bytes, Base.nonmissingtype(eltype(output)), intermediate_shape; fill_value)
     # Phase 1 reverse: array->array codecs (reverse order)
     for codec in reverse(collect(p.array_array))
         arr = Codecs.V3Codecs.codec_decode(codec, arr)

--- a/test/v3_codecs.jl
+++ b/test/v3_codecs.jl
@@ -894,6 +894,25 @@ end
         g2 = zopen(store)
         @test g2["myarray"][:] == Float64.(1:10)
     end
+
+    @testset "fill_as_missing for v3 arrays" begin
+        mktempdir() do dir
+            path = joinpath(dir, "fillmiss.zarr")
+            a = zcreate(Float64, 4, 6; path=path, zarr_format=3,
+                chunks=(2, 3), fill_value=0.0)
+            a[1:2, 1:3] = reshape(1.0:6.0, 2, 3)
+
+            b = zopen(path; fill_as_missing=true)
+            @test eltype(b) == Union{Missing,Float64}
+            @test b[1:2, 1:3] == reshape(1.0:6.0, 2, 3)
+            @test all(ismissing, b[3:4, 4:6])
+
+            c = zopen(path)
+            @test eltype(c) == Float64
+            @test c[1:2, 1:3] == reshape(1.0:6.0, 2, 3)
+            @test all(==(0.0), c[3:4, 4:6])
+        end
+    end
 end
 
 @testset "Read Python-generated v3 fixtures" begin


### PR DESCRIPTION
**Broken:** `fill_as_missing=true` on any zarr v3 array threw `ArgumentError: cannot reinterpret UInt8 as Union{Missing, Float64}` as soon as an initialized chunk was read. `lib/ZarrCore/src/pipeline.jl:45` (`pipeline_decode!(::V3Pipeline, ...)`) passed `eltype(output)` — the `Union{T,Missing}` of the `SenMissArray` — to `codec_decode`, which reinterprets raw bytes. The stored elements are plain `T`; the v2 path already strips `Missing` in `zuncompress`.

**Fix:** pass `Base.nonmissingtype(eltype(output))` instead (one line).

**Test:** `test/v3_codecs.jl`, testset `"fill_as_missing for v3 arrays"` — create a v3 array, write one chunk, reopen with `fill_as_missing=true`, check eltype, the written chunk, and that the untouched chunk reads as `missing`. Fails before, passes after.

Stacked on #330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Qme1Mr9UxwceM15pWBG2k
