### PR TITLE
Fix complex v3 data_type names (complex64/complex128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   `DateTime64`, `PermanentZarrCache`, `BloscCodec`, and `GzipCodec` through `Zarr`.
 - Declare an explicit public API [#317](https://github.com/JuliaIO/Zarr.jl/pull/317). Every store, codec, filter and compressor type, and every documented extension point, is now `public`; the set of exported names is unchanged. Internals (`Metadata`, `ZarrFormat`, `is_zarray`, `is_zgroup`, `normalize_path`, `MaxLengthString`, ...) are no longer reachable as `Zarr.x` and must be accessed via `Zarr.ZarrCore.x`
 - Fixed `fill_as_missing=true` on zarr v3 arrays, which threw `cannot reinterpret UInt8 as Union{Missing,Float64}` when decoding an initialized chunk.
+- Fixed zarr v3 `ComplexF32`/`ComplexF64` arrays, which wrote `data_type` as `"complexf32"`/`"complexf64"` (now the spec names `"complex64"`/`"complex128"`; old names still read) and encoded complex fill values as `{"re","im"}` instead of `[real, imag]`, so they could not be reopened.
 
 ## v0.10.2 - 2026-08-19
 

--- a/Zarr/test/v3_codecs.jl
+++ b/Zarr/test/v3_codecs.jl
@@ -913,6 +913,40 @@ end
             @test all(==(0.0), c[3:4, 4:6])
         end
     end
+
+    @testset "complex data_type names (spec-compliant)" begin
+        for (T, wirename) in ((ComplexF32, "complex64"), (ComplexF64, "complex128"))
+            mktempdir() do dir
+                path = joinpath(dir, "complex.zarr")
+                a = zcreate(T, 4, 6; path=path, zarr_format=3, chunks=(2, 3))
+                @test eltype(a) == T
+
+                doc = JSON.parse(read(joinpath(path, "zarr.json"), String))
+                @test doc["data_type"] == wirename
+
+                data = T.(reshape(1:24, 4, 6)) .+ 2im
+                a[:, :] = data
+
+                b = zopen(path)
+                @test eltype(b) == T
+                @test b[:, :] == data
+            end
+        end
+    end
+
+    @testset "complex data_type legacy-name read compat" begin
+        for (name, T) in (("complexf32", ComplexF32), ("complexf64", ComplexF64))
+            store = Zarr.DictStore()
+            json_str = """{"zarr_format":3,"node_type":"array","shape":[4],"data_type":"$name",
+                "chunk_grid":{"name":"regular","configuration":{"chunk_shape":[4]}},
+                "chunk_key_encoding":{"name":"default","configuration":{"separator":"/"}},
+                "fill_value":[0.0,0.0],
+                "codecs":[{"name":"bytes","configuration":{"endian":"little"}}]}"""
+            store["zarr.json"] = Vector{UInt8}(json_str)
+            z = zopen(store)
+            @test eltype(z) == T
+        end
+    end
 end
 
 @testset "Read Python-generated v3 fixtures" begin

--- a/ZarrCore/src/metadata.jl
+++ b/ZarrCore/src/metadata.jl
@@ -266,6 +266,8 @@ end
 
 fill_value_encoding(v) = v
 fill_value_encoding(::Nothing)=nothing
+# spec: complex fill values are `[real, imag]`; without this the JSON lowering is `{"re":..,"im":..}`
+fill_value_encoding(v::Complex) = Any[real(v), imag(v)]
 function fill_value_encoding(v::AbstractFloat)
     if isnan(v)
         "NaN"

--- a/ZarrCore/src/metadata.jl
+++ b/ZarrCore/src/metadata.jl
@@ -267,7 +267,7 @@ end
 fill_value_encoding(v) = v
 fill_value_encoding(::Nothing)=nothing
 # spec: complex fill values are `[real, imag]`; without this the JSON lowering is `{"re":..,"im":..}`
-fill_value_encoding(v::Complex) = Any[real(v), imag(v)]
+fill_value_encoding(v::Complex) = [real(v), imag(v)]
 function fill_value_encoding(v::AbstractFloat)
     if isnan(v)
         "NaN"

--- a/ZarrCore/src/metadata3.jl
+++ b/ZarrCore/src/metadata3.jl
@@ -9,10 +9,16 @@ end
 typemap3["complex64"] = ComplexF32
 typemap3["complex128"] = ComplexF64
 typemap3["string"] = String
+# legacy names written by the `lowercase(string(T))` fallback before the explicit `typestr3` methods below
+typemap3["complexf32"] = ComplexF32
+typemap3["complexf64"] = ComplexF64
 
 function typestr3(t::Type)
     return lowercase(string(t))
 end
+
+typestr3(::Type{ComplexF32}) = "complex64"
+typestr3(::Type{ComplexF64}) = "complex128"
 
 function typestr3(::Type{MaxLengthString{N, UInt32}}) where {N}
     return Dict{String, Any}(


### PR DESCRIPTION
**Broken:** `ZarrCore/src/metadata3.jl:13` — the generic `typestr3(t::Type) = lowercase(string(t))` wrote `data_type` as `"complexf32"`/`"complexf64"` for `ComplexF32`/`ComplexF64`. The spec names are `"complex64"`/`"complex128"`, which is all `typemap3` reads, so a complex v3 array could never be reopened (`KeyError: key "complexf32" not found`).

**Fix:** explicit `typestr3(::Type{ComplexF32/F64})` methods returning the spec names, plus `typemap3` aliases for the old names so already-written stores still open.

Bundled: `fill_value_encoding(::Complex)` in `ZarrCore/src/metadata.jl` now emits the spec's `[real, imag]` instead of the JSON struct lowering `{"re","im"}`. v3 creation always synthesizes a `zero(T)` fill value, so without this no complex v3 array could be reopened and the `data_type` fix could not be tested end-to-end.

**Tests:** `Zarr/test/v3_codecs.jl` — `"complex data_type names (spec-compliant)"` (write, check `zarr.json`, round-trip via `zopen`) and `"complex data_type legacy-name read compat"` (hand-built `zarr.json` with the old names opens with the right eltype).

Validation after rebasing: `Zarr/test/v3_codecs.jl` passed all 211 checks on Julia 1.13.

Stacked on #339 (`top-level-package-workspace`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Qme1Mr9UxwceM15pWBG2k
